### PR TITLE
Release 1.3.3

### DIFF
--- a/.github/workflows/docker-buildx-main.yml
+++ b/.github/workflows/docker-buildx-main.yml
@@ -39,7 +39,7 @@ jobs:
           --platform linux/amd64,linux/arm64,linux/arm/v7 \
           -f docker/Dockerfile.main \
           -t luligu/matterbridge:latest \
-          -t luligu/matterbridge:1.3.2 \
+          -t luligu/matterbridge:1.3.3 \
           --push .
         docker manifest inspect luligu/matterbridge:latest
       timeout-minutes: 60  

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ node_storage
 Eve door_history.json
 
 # Dockerfile
+
+migrationV8.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2024-06-22
+
+### Changed
+- [matterbridge]: Updated dependencies
+- [matterbridge]: When a plugin is in an error state, the bridge does not start to avoid causing the controllers to delete the registered devices and lose the configuration (e.g. room and automations).
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
+
 ## [1.3.2] - 2024-06-22
 
 New plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@project-chip/matter-node.js": "^0.9.2",
         "body-parser": "^1.20.2",
         "express": "^4.19.2",
-        "matter-history": "^1.1.1",
+        "matter-history": "^1.1.2",
         "node-ansi-logger": "^1.9.5",
         "node-persist-manager": "^1.0.7",
         "ws": "^8.17.1"
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@tsconfig/node-lts": "^20.1.3",
         "@types/express": "^4.17.21",
-        "@types/node": "^20.14.7",
+        "@types/node": "^20.14.8",
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "@typescript-eslint/parser": "^7.13.1",
@@ -362,9 +362,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
-      "integrity": "sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2014,12 +2014,12 @@
       "peer": true
     },
     "node_modules/matter-history": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/matter-history/-/matter-history-1.1.1.tgz",
-      "integrity": "sha512-qFnt4T+GVK2Epa+3MeQ5FXmt+kVwX6+ukc+M0WUfVvuFPrfCsDD/RurP/JZwUahI1J1wOQE+/yvFEwUp8TJO7Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matter-history/-/matter-history-1.1.2.tgz",
+      "integrity": "sha512-6oJIjK8KIt24sS+T+ywaVwBJhaz8Sid17q1RkSyP1PSqDzMRPvos2F5jBzgqTA++Ijq/AXoVfu8WlG/s/YhBlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@project-chip/matter-node.js": "^0.9.1",
+        "@project-chip/matter-node.js": "^0.9.2",
         "moment": "^2.30.1",
         "node-ansi-logger": "^1.9.5"
       },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@tsconfig/node-lts": "^20.1.3",
     "@types/express": "^4.17.21",
-    "@types/node": "^20.14.7",
+    "@types/node": "^20.14.8",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
@@ -94,7 +94,7 @@
     "@project-chip/matter-node.js": "^0.9.2",
     "body-parser": "^1.20.2",
     "express": "^4.19.2",
-    "matter-history": "^1.1.1",
+    "matter-history": "^1.1.2",
     "node-ansi-logger": "^1.9.5",
     "node-persist-manager": "^1.0.7",
     "ws": "^8.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Matterbridge plugin manager for Matter",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,14 +39,33 @@ export * from './matterbridgeDevice.js';
 export * from './matterbridgePlatform.js';
 export * from './matterbridgeAccessoryPlatform.js';
 export * from './matterbridgeDynamicPlatform.js';
+
 export * from './cluster/AirQualityCluster.js';
-export * from './cluster/TvocCluster.js';
-export * from './cluster/CarbonMonoxideConcentrationMeasurementCluster.js';
 export * from './cluster/BooleanStateConfigurationCluster.js';
-export * from './cluster/PowerTopologyCluster.js';
-// export * from './cluster/FanControlCluster.js'; // Already defined in matter.js like rev. 2
+export * from './cluster/CarbonDioxideConcentrationMeasurementCluster.js';
+export * from './cluster/CarbonMonoxideConcentrationMeasurementCluster.js';
+export * from './cluster/ConcentrationMeasurementCluster.js';
+export * from './cluster/DeviceEnergyManagementCluster.js';
+export * from './cluster/DeviceEnergyManagementModeCluster.js';
 export * from './cluster/ElectricalEnergyMeasurementCluster.js';
 export * from './cluster/ElectricalPowerMeasurementCluster.js';
+export * from './cluster/FormaldehydeConcentrationMeasurementCluster.js';
+export * from './cluster/MeasurementAccuracy.js';
+export * from './cluster/MeasurementAccuracyRange.js';
+export * from './cluster/MeasurementType.js';
+export * from './cluster/NitrogenDioxideConcentrationMeasurementCluster.js';
+export * from './cluster/OzoneConcentrationMeasurementCluster.js';
+export * from './cluster/Pm10ConcentrationMeasurementCluster.js';
+export * from './cluster/Pm1ConcentrationMeasurementCluster.js';
+export * from './cluster/Pm25ConcentrationMeasurementCluster.js';
+export * from './cluster/PowerTopologyCluster.js';
+export * from './cluster/RadonConcentrationMeasurementCluster.js';
+export * from './cluster/SmokeCoAlarmCluster.js';
+export * from './cluster/TvocCluster.js';
+
+// export * from './cluster/BridgedDeviceBasicInformationCluster.js'; // Already defined in matter.js like rev. 2
+// export * from './cluster/FanControlCluster.js'; // Already defined in matter.js like rev. 2
+
 export * from './utils.js';
 
 async function main() {


### PR DESCRIPTION
## [1.3.3] - 2024-06-22

### Changed
- [matterbridge]: Updated dependencies
- [matterbridge]: When a plugin is in an error state, the bridge does not start to avoid causing the controllers to delete the registered devices and lose the configuration (e.g. room and automations).

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>
