### PR TITLE
Plugin authors can be undefined

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -250,7 +250,7 @@ function Home() {
                     <td><Tooltip title={plugin.path}>{plugin.name}</Tooltip></td>
                     <td>{plugin.description}</td>
                     <td><Tooltip title="Update the plugin to the latest version">{plugin.latestVersion === undefined || plugin.latestVersion === plugin.version ? plugin.version : <span className="status-warning" onClick={() => handleUpdate(index)}>{`${plugin.version} -> ${plugin.latestVersion}`}</span>}</Tooltip></td>
-                    <td>{plugin.author.replace('https://github.com/', '')}</td>
+                    <td>{plugin.author?.replace('https://github.com/', '')}</td>
                     <td>{plugin.type === 'DynamicPlatform'?'Dynamic':'Accessory'}</td>
                     <td>{plugin.registeredDevices}</td>
                     <td>  


### PR DESCRIPTION
First of all, great work!

I recently installed this and added the [matterbridge-home-assistant](https://github.com/t0bst4r/matterbridge-home-assistant) plugin, and could no longer load the frontend because the plugin doesn't specify an author:
```
TypeError: e.author is undefined
    children Home.js:253
    cx Home.js:246
    React 8
    S scheduler.production.min.js:13
    R scheduler.production.min.js:14
    7234 scheduler.production.min.js:14
    Webpack 12
react-dom.production.min.js:189:29
```