### PR TITLE
Release 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The HomePods, being a WiFi devices, sometimes pruduce message trasmission errors
 
 All issues have been solved from the version 17.5 of the HomePod/AppleTV. Now they are stable.
 
-If you have more then one Apple TV or Home Pod, I get better results setting to disabled "Automatic Selection" in "Home Setting", "Home Hubs & Bridges". Once "Automatic selection" is disabled, select your Apple Tv if you have one or any of your Home Pod. In this way you should not have anymore more then one session for fabric.
+If you have more then one Apple TV or Home Pod, you can herve better results setting to disabled "Automatic Selection" in "Home Setting", "Home Hubs & Bridges". When "Automatic selection" is disabled, select your Apple Tv if you have one or any of your Home Pod. In this way you should not have anymore more then one session for fabric.
 
 ## Home Assistant
 


### PR DESCRIPTION
## [1.6.1] - 2024-11-02

### Added

- [matterbridge]: Added automatic recovery for matterbridge node storage when it gets corrupted for a power outage or hardware failure. Unattended setups can automatically recover restoring the previous automatic backup.
- [matterbridge]: Added automatic recovery for matter storage when it gets corrupted for a power outage or hardware failure. Unattended setups can automatically recover restoring the previous automatic backup.
- [matterbridge]: Added parameter "-norestore" to avoid to restore automatically. In this case you need to manually restore the storages from a full backup made from the frontend.

### Changed

- [loggers]: Logging on file keeps the logger level of the logger (matterbridge and matter logs).
- [matterbridge]: Added more api to WebSocket for the Matterbridge cockpit dashboard (Shelly gateway).
- [package]: Update dependencies.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>
