### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Feel free to join (the link is now permanent)!
 
 - [loggers]: Logging on file keeps the logger level of the logger (matterbridge and matter logs).
 - [matterbridge]: Added more api to WebSocket for the Matterbridge cockpit dashboard (Shelly gateway).
-- [package]: Update dependencies.
+- [package]: Update dependencies. 
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="./yellow-button.png" alt="Buy me a coffee" width="120">


### PR DESCRIPTION
## [1.6.1] - 2024-11-02

### Added

- [matterbridge]: Added automatic recovery for matterbridge node storage when it gets corrupted for a power outage or hardware failure. Unattended setups can automatically recover restoring the previous automatic backup.
- [matterbridge]: Added automatic recovery for matter storage when it gets corrupted for a power outage or hardware failure. Unattended setups can automatically recover restoring the previous automatic backup.
- [matterbridge]: Added parameter "-norestore" to avoid to restore automatically. In this case you need to manually restore the storages from a full backup made from the frontend.

### Changed

- [loggers]: Logging on file keeps the logger level of the logger (matterbridge and matter logs).
- [matterbridge]: Added more api to WebSocket for the Matterbridge cockpit dashboard (Shelly gateway).
- [package]: Update dependencies. 

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>