### PR TITLE
Reduce media query for small screens

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -333,9 +333,9 @@ h3 {
 }
 
 /* Styles for mobile screens */
-@media (max-width: 1600px) {
+@media (max-width: 1130px) {
   .MbfScreen {
-    width: 1600px;
+    width: 1130px;
     height: 800px;
   }
 }


### PR DESCRIPTION
Otherwise the @media query triggers on a 1920px width screen with 125% DPI (1530px width), causing horizontal scrolling.  1130px seems to be the actual minimum required to contain the elements.