### PR TITLE
Release 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,12 @@ matterbridge-hass v. 0.0.8
 ### Added
 
 - [frontend]: Added memorycheck before cleanup.
+- [platform]: Added a check for not latin characters.
+- [platform]: Added a check for already registered device names.
 
+### Changed
+
+- [package]: Update matter.js to 0.12.3.
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="./yellow-button.png" alt="Buy me a coffee" width="120">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ matterbridge-zigbee2mqtt v. 2.4.4
 matterbridge-somfy-tahoma v. 1.2.3
 matterbridge-hass v. 0.0.8
 
-## [2.1.4] - 2025-02-05
+## [2.1.4] - 2025-02-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,15 @@ You need to update all plugins you use and Matterbridge in the same moment.
 
 I suggest to first update all plugins without restarting and then to update Matterbridge so when it restarts, all versions will be the latest.
 
+If you use docker, all plugins are already installed in the image so you just need to pull the new image.
+
 Compatibility list:
 matterbridge-shelly v. 1.1.5
 matterbridge-zigbee2mqtt v. 2.4.4
 matterbridge-somfy-tahoma v. 1.2.3
 matterbridge-hass v. 0.0.8
 
-## [2.1.4] - 2025-02-06
+## [2.1.4] - 2025-02-07
 
 ### Added
 
@@ -42,6 +44,7 @@ matterbridge-hass v. 0.0.8
 ### Changed
 
 - [package]: Update matter.js to 0.12.3.
+- [matter.js]: Since matter.js storage cannot properly encode non latin names, they are encoded before passing them to matter.js.
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="./yellow-button.png" alt="Buy me a coffee" width="120">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Starting from v. 2.1.0, the legacy old api of matter.js have been completely rem
 
 For this reason there is no compatibility with the old versions of the plugins.
 
-You need to update all plugins you use and Matterbridge in the same moment. 
+You need to update all plugins you use and Matterbridge in the same moment.
 
 I suggest to first update all plugins without restarting and then to update Matterbridge so when it restarts, all versions will be the latest.
 
@@ -30,6 +30,17 @@ matterbridge-shelly v. 1.1.5
 matterbridge-zigbee2mqtt v. 2.4.4
 matterbridge-somfy-tahoma v. 1.2.3
 matterbridge-hass v. 0.0.8
+
+## [2.1.4] - 2025-02-05
+
+### Added
+
+- [frontend]: Added memorycheck before cleanup.
+
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
+</a>
 
 ## [2.1.3] - 2025-02-04
 

--- a/README-DOCKER.md
+++ b/README-DOCKER.md
@@ -48,10 +48,12 @@ The container must have full access to the host network (needed for mdns).
 
 ```
 sudo docker run --name matterbridge \
-  -v ${HOME}/Matterbridge:/root/Matterbridge \
-  -v ${HOME}/.matterbridge:/root/.matterbridge \
+  -v /home/<USER>/Matterbridge:/root/Matterbridge \
+  -v /home/<USER>/.matterbridge:/root/.matterbridge \
   --network host --restart always -d luligu/matterbridge:latest
 ```
+
+Replace USER with your user name (i.e. ubuntu or pi).
 
 You may need to adapt the script to your setup.
 
@@ -63,13 +65,15 @@ The docker-compose.yml file is available in the docker directory of the package
 services:
   matterbridge:
     container_name: matterbridge
-    image: luligu/matterbridge:latest                     # Matterbridge image with the latest tag
-    network_mode: host                                    # Ensures the Matter mdns works
-    restart: always                                       # Ensures the container always restarts automatically
+    image: luligu/matterbridge:latest                         # Matterbridge image with the tag latest
+    network_mode: host                                        # Ensures the Matter mdns works
+    restart: always                                           # Ensures the container always restarts automatically
     volumes:
-      - "${HOME}/Matterbridge:/root/Matterbridge"         # Mounts the Matterbridge plugin directory
-      - "${HOME}/.matterbridge:/root/.matterbridge"       # Mounts the Matterbridge storage directory
+      - "/home/<USER>/Matterbridge:/root/Matterbridge"        # Mounts the Matterbridge plugin directory
+      - "/home/<USER>/.matterbridge:/root/.matterbridge"      # Mounts the Matterbridge storage directory
 ```
+
+Replace USER with your user name (i.e. ubuntu or pi).
 
 copy it in the home directory or edit the existing one to add the matterbridge service.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.93",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.93.tgz",
-      "integrity": "sha512-M+29jTcfNNoR9NV7la4SwUqzWAxEwnc7ThA5e1m6LRSotmpfpCpLcIfgtSCVL+MllNLgAyM/5ru86iMRemPzDQ==",
+      "version": "1.5.94",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.94.tgz",
+      "integrity": "sha512-v+oaMuy6AgwZ6Hi2u5UgcM3wxzeFscBTsZBQL2FoDTx/T6k1XEQKz++8fe1VlQ3zjXB6hcvy5JPb5ZSkmVtdIQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge",
-  "version": "2.1.4-dev.2",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge",
-      "version": "2.1.4-dev.2",
+      "version": "2.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@matter/main": "0.12.3",
@@ -2659,9 +2659,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+      "version": "1.0.30001698",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz",
+      "integrity": "sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==",
       "dev": true,
       "funding": [
         {
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.94",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.94.tgz",
-      "integrity": "sha512-v+oaMuy6AgwZ6Hi2u5UgcM3wxzeFscBTsZBQL2FoDTx/T6k1XEQKz++8fe1VlQ3zjXB6hcvy5JPb5ZSkmVtdIQ==",
+      "version": "1.5.95",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.95.tgz",
+      "integrity": "sha512-XNsZaQrgQX+BG37BRQv+E+HcOZlWhqYaDoVVNCws/WrYYdbGrkR1qCDJ2mviBF3flCs6/BTa4O7ANfFTFZk6Dg==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge",
-  "version": "2.1.3",
+  "version": "2.1.4-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge",
-      "version": "2.1.3",
+      "version": "2.1.4-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@matter/main": "0.12.2",
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+      "version": "1.5.92",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
+      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5576,9 +5576,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.4-dev.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/main": "0.12.2",
+        "@matter/main": "0.12.3",
         "archiver": "7.0.1",
         "express": "4.21.2",
         "glob": "11.0.1",
@@ -1319,65 +1319,65 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.12.2.tgz",
-      "integrity": "sha512-D8S2CQHD7KI8L9lxeRgFCLDziXZRAEHqAJei7e0d5Jqh5thPH6S2HUcSX+je6EZDFTshguMgboW09lhXnUR8lA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.12.3.tgz",
+      "integrity": "sha512-1dya8bKRAhNkXD5xDWapVSO4Wfug8Qw2RWw74NZQNtGKbyBuNQsCnShtOdYGLnkjf/7XUGsYGmCG8hKepBHnbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.8.1"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.12.2.tgz",
-      "integrity": "sha512-bMHBLKmXpLmV/bkOxyhc+j+BhagFg5W6x/TJjfdZv0dZolkD1yT5zGZClmdGaLhhvyuYEKGKlecCM9uQksgxnA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.12.3.tgz",
+      "integrity": "sha512-PjbSuQfm7pv/opqODgU7JhA5Gj/6TxiFiDr+i4NWFit+/NyVorDpjCKTpCZmj3XD7QhEp0iKeDG7KKBqrQ4TUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.12.2",
-        "@matter/model": "0.12.2",
-        "@matter/node": "0.12.2",
-        "@matter/protocol": "0.12.2",
-        "@matter/types": "0.12.2",
+        "@matter/general": "0.12.3",
+        "@matter/model": "0.12.3",
+        "@matter/node": "0.12.3",
+        "@matter/protocol": "0.12.3",
+        "@matter/types": "0.12.3",
         "@noble/curves": "^1.8.1"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.12.2"
+        "@matter/nodejs": "0.12.3"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.12.2.tgz",
-      "integrity": "sha512-xM8hwqVepb6YpvjE9jXacA4YypPHJm0latei7YTZystgvh8lUHDk5dkLELyrXzbNYTs//LMPAbj6SIsz9CorPA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.12.3.tgz",
+      "integrity": "sha512-wuiBuUR45lno2PMx1YPhwZyaG7+20iBlb5SlnzYfI5j6fJv1WyYv22APDDPKDglPj4rP2RABCyCUfd1/K5EfXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.12.2",
+        "@matter/general": "0.12.3",
         "@noble/curves": "^1.8.1"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.12.2.tgz",
-      "integrity": "sha512-/VHnBHf6bFf6fVP6SvTrJDtKCzfZ6j5DTuEPRQFbdH1ph7OGyzVXjVRwoLPTzo2XT/VrTPcFNB38UNxTky1zQA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.12.3.tgz",
+      "integrity": "sha512-+bIYQtjCR053lgCd8mlnIp6ufm+H+zJGlZp8cdMX6IkkvT0vRqF2QxDtHpQn8CtzjnFzg+O5j0R4jdss2SluXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.12.2",
-        "@matter/model": "0.12.2",
-        "@matter/protocol": "0.12.2",
-        "@matter/types": "0.12.2",
+        "@matter/general": "0.12.3",
+        "@matter/model": "0.12.3",
+        "@matter/protocol": "0.12.3",
+        "@matter/types": "0.12.3",
         "@noble/curves": "^1.8.1"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.12.2.tgz",
-      "integrity": "sha512-sMnczk+3+7tr5OQDntPP7TuZP83/jC9jG713J1iJxU77cv/GMKIecKfAOrbFl50Ga+4zZTfIV9Mpekn50IT0ig==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.12.3.tgz",
+      "integrity": "sha512-Jx6TIYvl+2WlD9Zh6eMdClsjoPQjIkR3qhYGPbbhHlO7QXZWZz7d83jo1yShHWQrqnnfqqrkXy6iLBphrZ4SSg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.12.2",
-        "@matter/node": "0.12.2",
-        "@matter/protocol": "0.12.2",
-        "@matter/types": "0.12.2",
+        "@matter/general": "0.12.3",
+        "@matter/node": "0.12.3",
+        "@matter/protocol": "0.12.3",
+        "@matter/types": "0.12.3",
         "node-localstorage": "^3.0.5"
       },
       "engines": {
@@ -1385,25 +1385,25 @@
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.12.2.tgz",
-      "integrity": "sha512-BhfPqRgnNy+Fx6VWffFtA8aGdspvzxp+TY5PJpAqExBLwGB/kc/knagOOfLvSjSyT/gdZmIxep3Iw2ycm7UYYA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.12.3.tgz",
+      "integrity": "sha512-mUL6rSXdm0LaS/i6bxjBQlZ/0fi8hXoinBytbKNkztfDOB9I3FeNlgp9FJxZ+ZJtrsPleMg4q+loLU7uNQi30w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.12.2",
-        "@matter/model": "0.12.2",
-        "@matter/types": "0.12.2",
+        "@matter/general": "0.12.3",
+        "@matter/model": "0.12.3",
+        "@matter/types": "0.12.3",
         "@noble/curves": "^1.8.1"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.12.2.tgz",
-      "integrity": "sha512-sTujir3YTDrbFnkccCrc9zdSx4AGRHdOeVBLPvVORNieHoKlBeKLBtCA9GsjRbbpnmSrpPe9Fl6z1MkCWblAmw==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.12.3.tgz",
+      "integrity": "sha512-4nlu7nCW+V/Sed1XkJoPvtdRz0wIv8o9YSDj4To3yGR77HDqK9nbLXxpM7J+PQmGQ0/xEX1ylWU9X2dSIsH8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.12.2",
-        "@matter/model": "0.12.2",
+        "@matter/general": "0.12.3",
+        "@matter/model": "0.12.3",
         "@noble/curves": "^1.8.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matterbridge",
-  "version": "2.1.4-dev.1",
+  "version": "2.1.4-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge",
-      "version": "2.1.4-dev.1",
+      "version": "2.1.4-dev.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@matter/main": "0.12.3",
@@ -3108,9 +3108,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.92",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
-      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
+      "version": "1.5.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.93.tgz",
+      "integrity": "sha512-M+29jTcfNNoR9NV7la4SwUqzWAxEwnc7ThA5e1m6LRSotmpfpCpLcIfgtSCVL+MllNLgAyM/5ru86iMRemPzDQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge",
-  "version": "2.1.4-dev.1",
+  "version": "2.1.4-dev.2",
   "description": "Matterbridge plugin manager for Matter",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge",
-  "version": "2.1.3",
+  "version": "2.1.4-dev.1",
   "description": "Matterbridge plugin manager for Matter",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge",
-  "version": "2.1.4-dev.2",
+  "version": "2.1.4",
   "description": "Matterbridge plugin manager for Matter",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "install:jest": "npm install --save-dev jest ts-jest @types/jest eslint-plugin-jest && npm run test"
   },
   "dependencies": {
-    "@matter/main": "0.12.2",
+    "@matter/main": "0.12.3",
     "archiver": "7.0.1",
     "express": "4.21.2",
     "glob": "11.0.1",

--- a/src/deviceManager.test.ts
+++ b/src/deviceManager.test.ts
@@ -10,7 +10,6 @@ import { MatterbridgeEndpoint } from './matterbridgeEndpoint.js';
 import { DeviceManager } from './deviceManager.js';
 import { PluginManager } from './pluginManager.js';
 import { contactSensor, occupancySensor } from './matterbridgeDeviceTypes.js';
-import { MdnsService } from '@matter/main/protocol';
 
 // Default colors
 const plg = '\u001B[38;5;33m';
@@ -38,9 +37,7 @@ describe('DeviceManager with mocked devices', () => {
 
   afterAll(async () => {
     // Close the Matterbridge instance
-    const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
     // Restore the mocked AnsiLogger.log method
     loggerLogSpy.mockRestore();
     // Restore the mocked console.log
@@ -195,7 +192,6 @@ describe('DeviceManager with real devices', () => {
     // Close the Matterbridge instance
     const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
     // Restore the mocked AnsiLogger.log method
     loggerLogSpy.mockRestore();
     // Restore the mocked console.log

--- a/src/frontend.test.ts
+++ b/src/frontend.test.ts
@@ -1166,9 +1166,7 @@ describe('Matterbridge frontend', () => {
       expect((matterbridge as any).plugins.size).toBe(0);
 
       // Close the Matterbridge instance
-      const server = matterbridge.serverNode;
       await matterbridge.destroyInstance();
-      await server?.env.get(MdnsService)[Symbol.asyncDispose]();
 
       expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `WebSocket server closed successfully`);
       expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.NOTICE, `Cleanup completed. Shutting down...`);

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -924,6 +924,20 @@ export class Frontend {
   }
 
   async stop() {
+    // Start the memory check. This will not allow the process to exit but will log the memory usage for 5 minutes.
+    if (hasParameter('memorycheck')) {
+      await new Promise<void>((resolve) => {
+        this.log.debug(`***Memory check started for ${getIntParameter('memorycheck') ?? 5 * 60 * 1000} ms`);
+        setTimeout(
+          () => {
+            this.log.debug(`***Memory check stopped after ${getIntParameter('memorycheck') ?? 5 * 60 * 1000} ms`);
+            resolve();
+          },
+          getIntParameter('memorycheck') ?? 5 * 60 * 1000,
+        );
+      });
+    }
+
     // Close the http server
     if (this.httpServer) {
       this.httpServer.close();
@@ -1015,7 +1029,7 @@ export class Frontend {
       };
 
       this.log.debug(
-        `***Cpu usage ${CYAN}${cpuUsage.padStart(6, ' ')} %${db} - Memory usage rss ${CYAN}${memoryUsage.rss}${db} heapTotal ${CYAN}${memoryUsage.heapTotal}${db} heapUsed ${CYAN}${memoryUsage.heapUsed}${db} external ${memoryUsage.external} arrayBuffers ${memoryUsage.arrayBuffers}`,
+        `***Cpu usage: ${CYAN}${cpuUsage.padStart(6, ' ')} %${db} - Memory usage: rss ${CYAN}${memoryUsage.rss}${db} heapTotal ${CYAN}${memoryUsage.heapTotal}${db} heapUsed ${CYAN}${memoryUsage.heapUsed}${db} external ${memoryUsage.external} arrayBuffers ${memoryUsage.arrayBuffers}`,
       );
     };
     interval();
@@ -1045,7 +1059,7 @@ export class Frontend {
       };
       // eslint-disable-next-line no-console
       console.log(
-        `${YELLOW}Cpu usage${db} ${CYAN}${memory.cpu.padStart(6, ' ')} %${db} - ${YELLOW}Memory usage${db} rss ${CYAN}${memoryUsage.rss}${db} heapTotal ${CYAN}${memoryUsage.heapTotal}${db} heapUsed ${CYAN}${memoryUsage.heapUsed}${db} external ${memoryUsage.external} arrayBuffers ${memoryUsage.arrayBuffers}${rs}`,
+        `${YELLOW}Cpu usage:${db} ${CYAN}${memory.cpu.padStart(6, ' ')} %${db} - ${YELLOW}Memory usage:${db} rss ${CYAN}${memoryUsage.rss}${db} heapTotal ${CYAN}${memoryUsage.heapTotal}${db} heapUsed ${CYAN}${memoryUsage.heapUsed}${db} external ${memoryUsage.external} arrayBuffers ${memoryUsage.arrayBuffers}${rs}`,
       );
     }
     this.memoryData = [];

--- a/src/matterbridge.bridge.test.ts
+++ b/src/matterbridge.bridge.test.ts
@@ -10,7 +10,6 @@ import { jest } from '@jest/globals';
 import { AnsiLogger, db, LogLevel, nf, rs, UNDERLINE, UNDERLINEOFF } from 'node-ansi-logger';
 import { Matterbridge } from './matterbridge.js';
 import { wait, waiter } from './utils/utils.js';
-import { MdnsService } from '@matter/main/protocol';
 import { Environment, StorageService } from '@matter/main';
 import path from 'path';
 import os from 'os';
@@ -83,7 +82,6 @@ describe('Matterbridge loadInstance() and cleanup() -bridge mode', () => {
   afterAll(async () => {
     // Restore all mocks
     jest.restoreAllMocks();
-    // console.log('Matterbridge test -bridge mode');
   }, 30000);
 
   test('Matterbridge.loadInstance(true) -bridge mode', async () => {
@@ -160,9 +158,7 @@ describe('Matterbridge loadInstance() and cleanup() -bridge mode', () => {
 
   test('Matterbridge.destroyInstance() -bridge mode', async () => {
     // Close the Matterbridge instance
-    const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
 
     expect((matterbridge as any).log.log).toHaveBeenCalledWith(LogLevel.NOTICE, `Cleanup completed. Shutting down...`);
   }, 60000);

--- a/src/matterbridge.childbridge.test.ts
+++ b/src/matterbridge.childbridge.test.ts
@@ -9,7 +9,6 @@ import { jest } from '@jest/globals';
 import { AnsiLogger, db, LogLevel, nf, rs, UNDERLINE, UNDERLINEOFF } from 'node-ansi-logger';
 import { Matterbridge } from './matterbridge.js';
 import { wait, waiter } from './utils/utils.js';
-import { MdnsService } from '@matter/main/protocol';
 import { Environment, StorageService } from '@matter/main';
 import path from 'path';
 import os from 'os';
@@ -82,7 +81,6 @@ describe('Matterbridge loadInstance() and cleanup() -childbridge mode', () => {
   afterAll(async () => {
     // Restore all mocks
     jest.restoreAllMocks();
-    // console.log('Matterbridge test -childbridge mode');
   });
 
   test('Matterbridge.loadInstance(true) -childbridge mode', async () => {

--- a/src/matterbridge.ts
+++ b/src/matterbridge.ts
@@ -1402,6 +1402,8 @@ export class Matterbridge extends EventEmitter {
       }
       this.hasCleanupStarted = false;
       this.initialized = false;
+    } else {
+      this.log.debug('Cleanup already started...');
     }
   }
 

--- a/src/matterbridge.ts
+++ b/src/matterbridge.ts
@@ -745,13 +745,13 @@ export class Matterbridge extends EventEmitter {
     process.removeAllListeners('unhandledRejection');
 
     this.exceptionHandler = async (error: Error) => {
-      this.log.fatal('Unhandled Exception detected at:', error.stack || error, rs);
+      this.log.error('Unhandled Exception detected at:', error.stack || error, rs);
       // await this.cleanup('Unhandled Exception detected, cleaning up...');
     };
     process.on('uncaughtException', this.exceptionHandler);
 
     this.rejectionHandler = async (reason, promise) => {
-      this.log.fatal('Unhandled Rejection detected at:', promise, 'reason:', reason instanceof Error ? reason.stack : reason, rs);
+      this.log.error('Unhandled Rejection detected at:', promise, 'reason:', reason instanceof Error ? reason.stack : reason, rs);
       // await this.cleanup('Unhandled Rejection detected, cleaning up...');
     };
     process.on('unhandledRejection', this.rejectionHandler);

--- a/src/matterbridgeAccessoryPlatform.test.ts
+++ b/src/matterbridgeAccessoryPlatform.test.ts
@@ -8,7 +8,6 @@ import { jest } from '@jest/globals';
 import { AnsiLogger } from 'node-ansi-logger';
 import { Matterbridge } from './matterbridge.js';
 import { MatterbridgeAccessoryPlatform } from './matterbridgeAccessoryPlatform.js';
-import { MdnsService } from '@matter/main/protocol';
 
 describe('Matterbridge accessory platform', () => {
   beforeAll(async () => {
@@ -41,9 +40,7 @@ describe('Matterbridge accessory platform', () => {
     expect(platform.type).toBe('AccessoryPlatform');
 
     // Close the Matterbridge instance
-    const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
     expect((Matterbridge as any).instance).toBeUndefined();
   }, 60000);
 });

--- a/src/matterbridgeDynamicPlatform.test.ts
+++ b/src/matterbridgeDynamicPlatform.test.ts
@@ -8,7 +8,6 @@ import { jest } from '@jest/globals';
 import { AnsiLogger, LogLevel } from 'node-ansi-logger';
 import { Matterbridge } from './matterbridge.js';
 import { MatterbridgeDynamicPlatform } from './matterbridgeDynamicPlatform.js';
-import { MdnsService } from '@matter/main/protocol';
 
 describe('Matterbridge dynamic platform', () => {
   beforeAll(async () => {
@@ -41,9 +40,7 @@ describe('Matterbridge dynamic platform', () => {
     expect(platform.type).toBe('DynamicPlatform');
 
     // Close the Matterbridge instance
-    const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
     expect((Matterbridge as any).instance).toBeUndefined();
   }, 60000);
 });

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -83,7 +83,6 @@ import {
   TotalVolatileOrganicCompoundsConcentrationMeasurementServer,
 } from '@matter/node/behaviors';
 import { updateAttribute } from './matterbridgeEndpointHelpers.js';
-import { MdnsService } from '@matter/main/protocol';
 
 describe('MatterbridgeEndpoint class', () => {
   let matterbridge: Matterbridge;
@@ -918,9 +917,11 @@ describe('MatterbridgeEndpoint class', () => {
       expect(device.getAttribute(AirQuality.Cluster.id, 'airQuality')).toBe(AirQuality.AirQualityEnum.Unknown);
     });
 
-    // eslint-disable-next-line jest/expect-expect
+    // eslint-disable-next-line jest/no-commented-out-tests
+    /*
     test('pause before cleanup', async () => {
       await new Promise((resolve) => setTimeout(resolve, 5000)); // Pause for 5 seconds
     }, 60000);
+    */
   });
 });

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -176,9 +176,7 @@ describe('MatterbridgeEndpoint class', () => {
 
   afterAll(async () => {
     // Close the Matterbridge instance
-    const server = matterbridge.serverNode;
     await matterbridge.destroyInstance();
-    await server?.env.get(MdnsService)[Symbol.asyncDispose]();
 
     // Restore all mocks
     jest.restoreAllMocks();

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -919,7 +919,7 @@ describe('MatterbridgeEndpoint class', () => {
 
     // eslint-disable-next-line jest/expect-expect
     test('pause before cleanup', async () => {
-      await new Promise((resolve) => setTimeout(resolve, 5000)); // Pause for 5 seconds
+      await new Promise((resolve) => setTimeout(resolve, 5000)); // Pause for 5 seconds to allow matter.js promises to settle
     }, 60000);
   });
 });

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -917,11 +917,9 @@ describe('MatterbridgeEndpoint class', () => {
       expect(device.getAttribute(AirQuality.Cluster.id, 'airQuality')).toBe(AirQuality.AirQualityEnum.Unknown);
     });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
-    /*
+    // eslint-disable-next-line jest/expect-expect
     test('pause before cleanup', async () => {
       await new Promise((resolve) => setTimeout(resolve, 5000)); // Pause for 5 seconds
     }, 60000);
-    */
   });
 });

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -345,7 +345,7 @@ describe('MatterbridgeEndpoint class', () => {
     test('close server node', async () => {
       expect(server).toBeDefined();
       await server.close();
-      await server.env.get(MdnsService)[Symbol.asyncDispose]();
+      await server.env.get(MdnsService)[Symbol.asyncDispose](); // loadInstance(false) does not start the mDNS service
     });
   });
 });

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -345,7 +345,7 @@ describe('MatterbridgeEndpoint class', () => {
     test('close server node', async () => {
       expect(server).toBeDefined();
       await server.close();
-      await server.env.get(MdnsService)[Symbol.asyncDispose](); // loadInstance(false) does not start the mDNS service
+      await server.env.get(MdnsService)[Symbol.asyncDispose](); // loadInstance(false) so destroyInstance() does not stop the mDNS service
     });
   });
 });

--- a/src/matterbridgeEndpoint.test.ts
+++ b/src/matterbridgeEndpoint.test.ts
@@ -260,6 +260,34 @@ describe('MatterbridgeEndpoint class', () => {
       expect(uniqueHashes.size).toBe(hashes.length); // Ensure no hash collisions
     });
 
+    test('constructor with non latin', async () => {
+      const nonLatinNames = [
+        '버튼 - 작은방 (버튼-작은방)',
+        '거실 공기 관리 - 샤오미 공기 청정기 속도 조절 (거실공기관리-샤오미공기청정기속도조절)',
+        '난방 - 온도관리 방법 설정 (난방-온도관리방법설정)',
+        '단후이 로봇청소기 예약/일정 (단후이로봇청소기예약/일정)',
+        '단후이 로봇청소기 시계/지역시간 설정(mqtt) (단후이로봇청소기시계/지역시간설정(mqtt))',
+        '애드온을 다시 시작(DuckDNS) (애드온을다시시작(DuckDNS))',
+        '외출 중 기기 제어 - 외출 3시간 이상시 끄기 (외출중기기제어-외출3시간이상시끄기)',
+        '메인 등(L1) 조명 자동 컨트롤 (메인등(L1)조명자동컨트롤)',
+        '작은방 공기 관리 - 샤오미 공기 청정기 속도 조절 (작은방공기관리-샤오미공기청정기속도조절)',
+        '알림 - haos 메모이 시용이 90% 이상으로 시스템을 재시작합니다 (알림-haos메모이시용이90%이상으로시스템을재시작합니다)',
+        '알림 - 가스 검침기의 카운트를 다시 설정해 주세요 (알림-가스검침기의카운트를다시설정해주세요)',
+        '알림 - 배달원이 고객님의 음식을 픽업했습니다 (알림-배달원이고객님의음식을픽업했습니다)',
+        '알림 - 조리기기 관리가 수동으로 변경되었습니다 (알림-조리기기관리가수동으로변경되었습니다)',
+        '알림 - 주문이 거의 도착했습니다 (알림-주문이거의도착했습니다)',
+        '알림 - 현재 외부에는 비가 오고 있습니다 (알림-현재외부에는비가오고있습니다)',
+        '알림 - NAS의 보안 위험이 감지 되었습니디.  보안 어드바이저를 확인해 주세요 (알림-NAS의보안위험이감지되었습니디보안어드바이저를확인해주세요)',
+      ];
+      let n = 1000;
+      for (const name of nonLatinNames) {
+        const device = new MatterbridgeEndpoint(onOffOutlet, { uniqueStorageKey: name, endpointId: EndpointNumber(n++) });
+        expect(device).toBeDefined();
+        expect(device.id).toBe(generateUniqueId(name));
+        await add(device);
+      }
+    });
+
     test('constructor', async () => {
       const deviceType = onOffLight;
       const device = new MatterbridgeEndpoint(deviceType, { uniqueStorageKey: 'OnOffLight1' });

--- a/src/matterbridgeEndpoint.test.ts
+++ b/src/matterbridgeEndpoint.test.ts
@@ -62,7 +62,6 @@ import {
   TimeSynchronizationServer,
 } from '@matter/node/behaviors';
 import { checkNotLatinCharacters, generateUniqueId, getAttributeId, getClusterId } from './matterbridgeEndpointHelpers.js';
-import { MdnsService } from '@matter/main/protocol';
 
 describe('MatterbridgeEndpoint class', () => {
   let matterbridge: Matterbridge;

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -67,6 +67,8 @@ import {
   getAttributeId,
   setAttribute,
   getAttribute,
+  checkNotLatinCharacters,
+  generateUniqueId,
 } from './matterbridgeEndpointHelpers.js';
 
 // @matter
@@ -290,6 +292,11 @@ export class MatterbridgeEndpoint extends Endpoint {
       behaviors: options.tagList ? SupportedBehaviors(DescriptorServer.with(Descriptor.Feature.TagList)) : {},
     };
     const endpointV8 = MutableEndpoint(deviceTypeDefinitionV8);
+
+    // Check if the uniqueStorageKey is valid
+    if (options.uniqueStorageKey && checkNotLatinCharacters(options.uniqueStorageKey)) {
+      options.uniqueStorageKey = generateUniqueId(options.uniqueStorageKey);
+    }
 
     // Convert the options to an Endpoint.Options
     const optionsV8 = {

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -111,6 +111,24 @@ export function lowercaseFirstLetter(name: string): string {
   return name.charAt(0).toLowerCase() + name.slice(1);
 }
 
+export function checkNotLatinCharacters(deviceName: string): boolean {
+  const nonLatinRegexList = [
+    /[\u0400-\u04FF\u0500-\u052F]/, // Cyrillic
+    /[\u2E80-\u9FFF]/, // CJK (Chinese, Japanese, Korean)
+    /[\uAC00-\uD7AF]/, // Korean Hangul
+    /[\u0600-\u06FF\u0750-\u077F]/, // Arabic, Persian
+    /[\u0590-\u05FF]/, // Hebrew
+    /[\u0900-\u097F]/, // Devanagari (Hindi, Sanskrit)
+    /[\u0E00-\u0E7F]/, // Thai
+    /[\u1200-\u137F]/, // Ethiopic (Amharic, Tigrinya)
+  ];
+  return nonLatinRegexList.some((regex) => regex.test(deviceName));
+}
+
+export function generateUniqueId(deviceName: string): string {
+  return createHash('md5').update(deviceName).digest('hex'); // MD5 hash of the device name
+}
+
 export function createUniqueId(param1: string, param2: string, param3: string, param4: string) {
   const hash = createHash('md5');
   hash.update(param1 + param2 + param3 + param4);

--- a/src/matterbridgePlatform.ts
+++ b/src/matterbridgePlatform.ts
@@ -164,8 +164,7 @@ export class MatterbridgePlatform {
       return;
     }
     if (device.deviceName && checkNotLatinCharacters(device.deviceName)) {
-      this.log.debug(`Device with name ${CYAN}${device.deviceName}${er} has not latin characters. Please keep the name as short as possible.`);
-      return;
+      this.log.debug(`Device with name ${CYAN}${device.deviceName}${db} has non latin characters.`);
     }
     await this.matterbridge.addBridgedEndpoint(this.name, device);
     if (device.uniqueId) this.registeredEndpoints.set(device.uniqueId, device);

--- a/src/matterbridgePlatform.ts
+++ b/src/matterbridgePlatform.ts
@@ -24,6 +24,7 @@
 // Matterbridge
 import { Matterbridge } from './matterbridge.js';
 import { MatterbridgeEndpoint } from './matterbridgeEndpoint.js';
+import { checkNotLatinCharacters } from './matterbridgeEndpointHelpers.js';
 import { isValidArray, isValidObject, isValidString } from './utils/utils.js';
 
 // AnsiLogger module
@@ -138,6 +139,10 @@ export class MatterbridgePlatform {
     device.plugin = this.name;
     if (device.deviceName && this.registeredEndpointsByName.has(device.deviceName)) {
       this.log.error(`Device with name ${CYAN}${device.deviceName}${er} is already registered. The device will not be added. Please change the device name.`);
+      return;
+    }
+    if (device.deviceName && checkNotLatinCharacters(device.deviceName)) {
+      this.log.debug(`Device with name ${CYAN}${device.deviceName}${er} has not latin characters. Please keep the name as short as possible.`);
       return;
     }
     await this.matterbridge.addBridgedEndpoint(this.name, device);

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -16,6 +16,7 @@ import {
   isValidNull,
   isValidUndefined,
   createZip,
+  getNpmPackageVersion,
 } from './utils';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -409,5 +410,37 @@ describe('Utils test', () => {
   it('should zip with an array', async () => {
     const size = await createZip(path.join('test', 'array.zip'), 'package.json', '*.js', path.join('src', 'utils'));
     expect(size).toBeGreaterThan(0);
+  }, 60000);
+
+  it('should get the latest version', async () => {
+    const version = await getNpmPackageVersion('matterbridge');
+    expect(version).toBeDefined();
+    expect(typeof version).toBe('string');
+    // console.log('Latest version:', version);
+  }, 60000);
+
+  it('should get the latest dev version', async () => {
+    const devVersion = await getNpmPackageVersion('matterbridge', 'dev', 1000);
+    expect(devVersion).toBeDefined();
+    expect(typeof devVersion).toBe('string');
+    // console.log('Latest version tag dev:', devVersion);
+  }, 60000);
+
+  it('should get version for tag latest and dev', async () => {
+    const version = await getNpmPackageVersion('matterbridge', 'latest', 1000);
+    expect(version).toBeDefined();
+    expect(typeof version).toBe('string');
+    // console.log('Latest version:', version);
+
+    const devVersion = await getNpmPackageVersion('matterbridge', 'dev', 1000);
+    expect(devVersion).toBeDefined();
+    expect(typeof devVersion).toBe('string');
+    // console.log('Latest version tag dev:', devVersion);
+
+    expect(devVersion).not.toBe(version);
+  }, 60000);
+
+  it('should not get the latest version of a non existing package', async () => {
+    await expect(getNpmPackageVersion('matterbridge1234567')).rejects.toThrow('Failed to fetch data. Status code: 404');
   }, 60000);
 });


### PR DESCRIPTION
### Breaking Changes

Starting from v. 2.0.0, Matterbridge is running only in mode edge (no parameter needed and no badge in the frontend).

Starting from v. 2.1.0, the legacy old api of matter.js have been completely removed from Matterbridge and from all plugins.

For this reason there is no compatibility with the old versions of the plugins.

You need to update all plugins you use and Matterbridge in the same moment.

I suggest to first update all plugins without restarting and then to update Matterbridge so when it restarts, all versions will be the latest.

If you use docker, all plugins are already installed in the image so you just need to pull the new image.

Compatibility list:
matterbridge-shelly v. 1.1.5
matterbridge-zigbee2mqtt v. 2.4.4
matterbridge-somfy-tahoma v. 1.2.3
matterbridge-hass v. 0.0.8

## [2.1.4] - 2025-02-07

### Added

- [frontend]: Added memorycheck before cleanup.
- [platform]: Added a check for not latin characters.
- [platform]: Added a check for already registered device names.

### Changed

- [package]: Update matter.js to 0.12.3.
- [matter.js]: Since matter.js storage cannot properly encode non latin names, they are encoded before passing them to matter.js.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="./yellow-button.png" alt="Buy me a coffee" width="120">
</a>
