### PR TITLE
Relative branch links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge changelog
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -260,7 +260,7 @@ matterbridge-hass v. 0.0.8
 
 ### Added
 
-- [edge]: Added guide https://github.com/Luligu/matterbridge/blob/dev/README-EDGE.md.
+- [edge]: Added guide [README-EDGE.md](README-EDGE.md).
 - [storage]: Added conversion from old matter storage to the new api format with fabrics, resumptionRecords, network, commissioning, operationalCredentials, acl and parts number. The conversion is triggered every time you shutdown or restart matterbridge till the new storage has been used with matterbridge edge.
 - [storage]: Added conversion for child endpoint numbers.
 - [storage]: Added conversion for childbridge mode.
@@ -397,7 +397,7 @@ It is possible that some controllers see them as new devices or need time to rea
 ### Added
 
 - [matter.js]: Almost completed the phase 2 of migration to edge (matter.js new API).
-- [nginx]: Added the route /matterbridge/ to be used with nginx proxy server https://github.com/Luligu/matterbridge/blob/dev/README-NGINX.md.
+- [nginx]: Added the route /matterbridge/ to be used with nginx proxy server [README-NGINX.md](README-NGINX.md).
 - [config]: Config and schema are loaded before loading the plugin to allow to configure the plugin even when it throws error on load.
 - [config]: Added version to the config.
 - [frontend]: Added badge "edge" when running in edge mode.
@@ -601,7 +601,7 @@ It is possible that some controllers see them as new devices or need time to rea
 
 ### Breaking Changes for developers
 
-- please read this [Development guide lines](https://github.com/Luligu/matterbridge/blob/main/README-DEV.md)
+- please read this [Development guide lines](README-DEV.md)
 
 ### Added
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)

--- a/README-DOCKER.md
+++ b/README-DOCKER.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)

--- a/README-EDGE.md
+++ b/README-EDGE.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge edge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge edge
 
 Matterbridge Edge is the version of Matterbridge running with the new Matter.js API.
 

--- a/README-NGINX.md
+++ b/README-NGINX.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)

--- a/README-PODMAN.md
+++ b/README-PODMAN.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)

--- a/README-SERVICE.md
+++ b/README-SERVICE.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Luligu/matterbridge/blob/main/frontend/public/matterbridge%2064x64.png" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
+# <img src="frontend/public/matterbridge.svg" alt="Matterbridge Logo" width="64px" height="64px">&nbsp;&nbsp;&nbsp;Matterbridge
 
 [![npm version](https://img.shields.io/npm/v/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
 [![npm downloads](https://img.shields.io/npm/dt/matterbridge.svg)](https://www.npmjs.com/package/matterbridge)
@@ -121,34 +121,34 @@ To use the frontend with ssl place the certificates in the .matterbridge/certs d
 From the frontend you can do all operations in an easy way.
 
 Home page:
-![See the screenshot here](https://github.com/Luligu/matterbridge/blob/main/screenshot/Screenshot%20home.jpg)
+![See the screenshot here](screenshot/Screenshot%20home.jpg)
 
 Devices page:
-[See the screenshot here](https://github.com/Luligu/matterbridge/blob/main/screenshot/Screenshot%20devices.jpg)
+[See the screenshot here](screenshot/Screenshot%20devices.jpg)
 
 Logs page:
-[See the screenshot here](https://github.com/Luligu/matterbridge/blob/main/screenshot/Screenshot%20logs.jpg)
+[See the screenshot here](screenshot/Screenshot%20logs.jpg)
 
 Config editor:
-[See the screenshot here](https://github.com/Luligu/matterbridge/blob/main/screenshot/Screenshot%20config%20editor.jpg)
+[See the screenshot here](screenshot/Screenshot%20config%20editor.jpg)
 
 ## Advanced configurations
 
 ### Run matterbridge as a daemon with systemctl (Linux only)
 
-[Service configurations](https://github.com/Luligu/matterbridge/blob/main/README-SERVICE.md)
+[Service configurations](README-SERVICE.md)
 
 ### Run matterbridge with docker and docker compose
 
-[Docker configurations](https://github.com/Luligu/matterbridge/blob/main/README-DOCKER.md)
+[Docker configurations](README-DOCKER.md)
 
 ### Run matterbridge with podman
 
-[Podman configurations](https://github.com/Luligu/matterbridge/blob/main/README-PODMAN.md)
+[Podman configurations](README-PODMAN.md)
 
 ### Run matterbridge with nginx
 
-[Nginx configurations](https://github.com/Luligu/matterbridge/blob/main/README-NGINX.md)
+[Nginx configurations](README-NGINX.md)
 
 ### Run matterbridge as an home assistant add-on with the official add-on
 
@@ -160,14 +160,14 @@ The other Home Assistant Community Add-ons and plugins are not verified to work 
 
 ## Development
 
-[Development](https://github.com/Luligu/matterbridge/blob/main/README-DEV.md)
+[Development](README-DEV.md)
 
 ## Plugins
 
 ### Shelly
 
 <a href="https://github.com/Luligu/matterbridge-shelly">
-  <img src="https://github.com/Luligu/matterbridge/blob/dev/screenshot/Shelly.png" alt="Shelly plugin logo" width="100" />
+  <img src="screenshot/Shelly.png" alt="Shelly plugin logo" width="100" />
 </a>
 
 Matterbridge shelly plugin allows you to expose all Shelly Gen 1, Gen 2, Gen 3 and BLU devices to Matter.
@@ -196,7 +196,7 @@ Features:
 ### Zigbee2MQTT
 
 <a href="https://github.com/Luligu/matterbridge-zigbee2mqtt">
-  <img src="https://github.com/Luligu/matterbridge/blob/dev/screenshot/Zigbee2MQTT.png" alt="Zigbee2MQTT plugin logo" width="100" />
+  <img src="screenshot/Zigbee2MQTT.png" alt="Zigbee2MQTT plugin logo" width="100" />
 </a>
 
 Matterbridge zigbee2mqtt is a matterbridge production-level plugin that expose all zigbee2mqtt devices and groups to Matter.
@@ -206,7 +206,7 @@ No hub or dedicated hardware needed.
 ### Somfy tahoma
 
 <a href="https://github.com/Luligu/matterbridge-somfy-tahoma">
-  <img src="https://github.com/Luligu/matterbridge/blob/dev/screenshot/Somfy.png" alt="Somfy plugin logo" width="100" />
+  <img src="screenshot/Somfy.png" alt="Somfy plugin logo" width="100" />
 </a>
 
 Matterbridge Somfy Tahoma is a matterbridge production-level plugin that expose the Somfy Tahoma screen devices to Matter.


### PR DESCRIPTION
Updated markdown files to use relative branch links, cleaning up branch inter-linking.
I.e. documents in /dev/ branch link to /dev/ and /main/ to /main/.