### PR TITLE
Fix missing import for clusters/operational-state in matterbridgeEndpoint.ts

### DIFF
--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -104,6 +104,7 @@ import { ElectricalEnergyMeasurement } from '@matter/main/clusters/electrical-en
 import { AirQuality } from '@matter/main/clusters/air-quality';
 import { ConcentrationMeasurement } from '@matter/main/clusters/concentration-measurement';
 import { OccupancySensing } from '@matter/main/clusters/occupancy-sensing';
+import { OperationalState } from '@matter/main/clusters/operational-state';
 import { ThermostatUserInterfaceConfiguration } from '@matter/main/clusters/thermostat-user-interface-configuration';
 import { OperationalState } from '@matter/main/clusters/operational-state';
 


### PR DESCRIPTION
Fix missing import for clusters/operational-state in matterbridgeEndpoint.ts causing this error:
```
src/matterbridgeEndpoint.ts:1903:64 - error TS2503: Cannot find namespace 'OperationalState'.

1903   createDefaultOperationalStateClusterServer(operationalState: OperationalState.OperationalStateEnum = OperationalState.OperationalStateEnum.Stopped): this {
                                                                    ~~~~~~~~~~~~~~~~
```
