### PR TITLE
Release 3.0.4

### DIFF
--- a/.github/workflows/publish-dev-daily.yml
+++ b/.github/workflows/publish-dev-daily.yml
@@ -71,7 +71,8 @@ jobs:
           PUBLISHED_SHA=${PUBLISHED##*-}
 
           # 4) get the current commit short-SHA
-          CURRENT_SHA=${GITHUB_SHA::7}
+          # CURRENT_SHA=${GITHUB_SHA::7}
+          CURRENT_SHA=$(git rev-parse --short=7 HEAD)
 
           echo "Published dev tag: $PUBLISHED"
           echo "Published SHA: $PUBLISHED_SHA"

--- a/.github/workflows/publish-dev-daily.yml
+++ b/.github/workflows/publish-dev-daily.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: dev
+          fetch-depth: 0
+          # Ensure full history is available for versioning
+          # This is important to ensure that the git SHA is accurate for the versioning
+          # and to allow the script to check if the dev version has changed since the last publish.
 
       - name: Set up Node.js & registry
         uses: actions/setup-node@v4
@@ -71,7 +75,6 @@ jobs:
           PUBLISHED_SHA=${PUBLISHED##*-}
 
           # 4) get the current commit short-SHA
-          # CURRENT_SHA=${GITHUB_SHA::7}
           CURRENT_SHA=$(git rev-parse --short=7 HEAD)
 
           echo "Published dev tag: $PUBLISHED"

--- a/.github/workflows/publish-dev-daily.yml
+++ b/.github/workflows/publish-dev-daily.yml
@@ -38,7 +38,8 @@ jobs:
           DATE=$(date -u +'%Y%m%d')
           SHA=$(git rev-parse --short=7 HEAD)
           DEV_TAG="${BASE}-dev-${DATE}-${SHA}"
-          echo "DEV_TAG=$DEV_TAG" >> $GITHUB_ENV
+          echo "DEV_TAG=$DEV_TAG"   >> $GITHUB_ENV
+          echo "ORIG_SHA=$SHA"      >> $GITHUB_ENV
 
       - name: Bump to date-stamped dev version (no git tag)
         run: npm version "${{ env.DEV_TAG }}" --no-git-tag-version
@@ -75,7 +76,7 @@ jobs:
           PUBLISHED_SHA=${PUBLISHED##*-}
 
           # 4) get the current commit short-SHA
-          CURRENT_SHA=$(git rev-parse --short=7 HEAD)
+          CURRENT_SHA=${ORIG_SHA}
 
           echo "Published dev tag: $PUBLISHED"
           echo "Published SHA: $PUBLISHED_SHA"

--- a/.github/workflows/publish-dev-daily.yml
+++ b/.github/workflows/publish-dev-daily.yml
@@ -38,8 +38,8 @@ jobs:
           DATE=$(date -u +'%Y%m%d')
           SHA=$(git rev-parse --short=7 HEAD)
           DEV_TAG="${BASE}-dev-${DATE}-${SHA}"
-          echo "DEV_TAG=$DEV_TAG"   >> $GITHUB_ENV
-          echo "ORIG_SHA=$SHA"      >> $GITHUB_ENV
+          echo "DEV_TAG=$DEV_TAG" >> $GITHUB_ENV
+          echo "ORIG_SHA=$SHA"    >> $GITHUB_ENV
 
       - name: Bump to date-stamped dev version (no git tag)
         run: npm version "${{ env.DEV_TAG }}" --no-git-tag-version

--- a/.github/workflows/publish-dev-daily.yml
+++ b/.github/workflows/publish-dev-daily.yml
@@ -59,7 +59,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # ensure npm can read the private or public registry
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+          npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 
           # 1) grab the package name
           PKG=$(node -p "require('./package.json').name")

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test
 *.heapsnapshot
 *.heapprofile
 crypto
+*.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
+- [jsdoc]: Improved explanation on jsdoc cluster helpers.
+
 ### Changed
 
-- [legacy]: Removed legacy matter.js EndpointServer.
+- [legacy]: Removed legacy matter.js EndpointServer and logEndpoint that will be removed in matter.js 0.14.0. For developers: if you need to log the endpoint the call is Logger.get('LogEndpoint').info(endpoint).
 - [package]: Updated dependencies.
 - [package]: Updated multer package to 2.0.0.
 
 ### Fixed
+
+- [virtualDevice]: Fixed possible vulnerability in the length of the nodeLabel.
 
 <a href="https://www.buymeacoffee.com/luligugithub">
   <img src="bmc-button.svg" alt="Buy me a coffee" width="80">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ If you like this project and find it useful, please consider giving it a star on
 
 ### Added
 
-- [jsdoc]: Improved explanation on jsdoc cluster helpers.
+- [jsdoc]: Improved jsdoc for cluster helpers.
 - [cover]: Added createDefaultTiltWindowCoveringClusterServer().
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ If you like this project and find it useful, please consider giving it a star on
   <img src="bmc-button.svg" alt="Buy me a coffee" width="120">
 </a>
 
+## [3.0.4] - 2025-05-??
+
+### Added
+
+### Changed
+
+- [legacy]: Removed legacy matter.js EndpointServer.
+- [package]: Updated dependencies.
+- [package]: Updated multer package to 2.0.0.
+
+### Fixed
+
+<a href="https://www.buymeacoffee.com/luligugithub">
+  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
+</a>
+
 ## [3.0.3] - 2025-05-19
 
 ### New plugins
@@ -23,10 +39,10 @@ AEG RX 9 / Electrolux Pure i9 robot vacuum plugin for Matterbridge.
 
 ### Added
 
-- [virtual] Added virtual devices configuration mode in the Matterbridge Settings: 'Disabled', 'Light', 'Outlet', 'Switch', 'Mounted_switch'. Switch is not supported by Alexa. Mounted Switch is not supported by Apple.
-- [deviceTypes] Added evse, waterHeater, solarPower, batteryStorage and heatPump device type.
-- [waterHeater] Added WaterHeater class to create a Water Heater Device Type in one line of code (thanks https://github.com/lboue).
-- [subscribe] Added a third parameter context (provisional implementation: when "context.offline === true" then this is a change coming from the device).
+- [virtual]: Added virtual devices configuration mode in the Matterbridge Settings: 'Disabled', 'Light', 'Outlet', 'Switch', 'Mounted_switch'. Switch is not supported by Alexa. Mounted Switch is not supported by Apple.
+- [deviceTypes]: Added evse, waterHeater, solarPower, batteryStorage and heatPump device type.
+- [waterHeater]: Added WaterHeater class to create a Water Heater Device Type in one line of code (thanks https://github.com/lboue).
+- [subscribe]: Added a third parameter context (provisional implementation: when "context.offline === true" then this is a change coming from the device).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ If you like this project and find it useful, please consider giving it a star on
   <img src="bmc-button.svg" alt="Buy me a coffee" width="120">
 </a>
 
-## [3.0.4] - 2025-05-??
+## [3.0.4] - 2025-05-26
 
 ### Added
 
 - [jsdoc]: Improved jsdoc for cluster helpers.
-- [cover]: Added createDefaultTiltWindowCoveringClusterServer().
+- [cover]: Added createDefaultLiftTiltWindowCoveringClusterServer() that create a window covering cluser with both lift and tilt features (supported by Apple Home).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If you like this project and find it useful, please consider giving it a star on
 ### Added
 
 - [jsdoc]: Improved explanation on jsdoc cluster helpers.
+- [cover]: Added createDefaultTiltWindowCoveringClusterServer().
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker Version](https://img.shields.io/docker/v/luligu/matterbridge?label=docker%20version&sort=semver)](https://hub.docker.com/r/luligu/matterbridge)
 [![Docker Pulls](https://img.shields.io/docker/pulls/luligu/matterbridge.svg)](https://hub.docker.com/r/luligu/matterbridge)
 ![Node.js CI](https://github.com/Luligu/matterbridge/actions/workflows/build.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Jest%20coverage-85%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Jest%20coverage-86%25-brightgreen)
 
 [![power by](https://img.shields.io/badge/powered%20by-matter--history-blue)](https://www.npmjs.com/package/matter-history)
 [![power by](https://img.shields.io/badge/powered%20by-node--ansi--logger-blue)](https://www.npmjs.com/package/node-ansi-logger)
@@ -86,7 +86,7 @@ Follow these steps to install Matterbridge:
 npm install -g matterbridge --omit=dev
 ```
 
-on Linux you may need the necessary permissions:
+on Linux or macOS you may need the necessary permissions:
 
 ```
 sudo npm install -g matterbridge --omit=dev
@@ -142,7 +142,7 @@ Here's how to specify a different port number:
 matterbridge -frontend [port number]
 ```
 
-To use the frontend with ssl place the certificates in the .matterbridge/certs directory: cert.pem, key.pem and ca.pem (optional).
+To use the frontend with ssl see below.
 
 From the frontend you can do all operations in an easy way.
 
@@ -196,7 +196,7 @@ The other Home Assistant Community Add-ons and plugins are not verified to work 
   <img src="screenshot/Shelly.svg" alt="Shelly plugin logo" width="100" />
 </a>
 
-Matterbridge shelly plugin allows you to expose all Shelly Gen 1, Gen 2, Gen 3 and BLU devices to Matter.
+Matterbridge shelly plugin allows you to expose all Shelly Gen 1, Gen 2, Gen 3 and Gen 4 and BLU devices to Matter.
 
 Features:
 
@@ -253,7 +253,7 @@ It is the ideal companion of the official [Matterbridge Home Assistant Add-on](h
   <img src="frontend/public/matterbridge.svg" alt="Matterbridge logo" width="100" />
 </a>
 
-Matterbridge Webhooks plugin allows you to expose any webhooks to Matter..
+Matterbridge Webhooks plugin allows you to expose any webhooks to Matter.
 
 ### BTHome
 
@@ -506,12 +506,6 @@ As of version 18.4.x, the Robot is supported by the Home app only as a single, n
 
 If a Robot is present alongside other devices in the bridge, the entire bridge becomes unstable in the Home app.
 
-### Concentration measurements clusters
-
-As of version 18.4.x, all cluster derived from the concentration measurement cluster hang the Home app while pairing and the entire bridge becomes unstable in the Home app.
-
-For example: air quality sensors with TVOC measurement or co sensors with CarbonMonoxide measurement.
-
 ## Home Assistant
 
 So far is the only controller supporting some Matter 1.2, 1.3 and 1.4 device type:
@@ -559,7 +553,7 @@ There is no support for these Matter device types:
 
 In the zigbee2mqtt and shelly plugins select the option to expose
 the switch devices like light or outlet cause they don't show up like switch
-(Matterbridge uses a modified switch device type without client cluster).
+(Matterbridge uses a switch device type without client cluster).
 
 ## SmartThings
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,7 @@ export default [
           ignoreRestSiblings: true,
           varsIgnorePattern: '^_', // Ignore unused variables starting with _
           argsIgnorePattern: '^_', // Ignore unused arguments starting with _
+          caughtErrorsIgnorePattern: '^_', // Ignore unused caught errors starting with _
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "matterbridge",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@matter/main": "0.13.0",
         "archiver": "7.0.1",
         "express": "5.1.0",
         "glob": "11.0.2",
-        "multer": "1.4.5-lts.2",
+        "multer": "2.0.0",
         "node-ansi-logger": "3.0.1",
         "node-persist-manager": "1.0.8",
         "ws": "8.18.2"
@@ -22,12 +22,12 @@
         "matterbridge": "dist/cli.js"
       },
       "devDependencies": {
-        "@eslint/js": "9.26.0",
+        "@eslint/js": "9.27.0",
         "@types/archiver": "6.0.3",
-        "@types/express": "5.0.1",
+        "@types/express": "5.0.2",
         "@types/jest": "29.5.14",
         "@types/multer": "1.4.12",
-        "@types/node": "22.15.18",
+        "@types/node": "22.15.21",
         "@types/ws": "8.18.1",
         "eslint-config-prettier": "10.1.5",
         "eslint-plugin-jest": "28.11.0",
@@ -37,7 +37,7 @@
         "eslint-plugin-react-hooks": "5.2.0",
         "jest": "29.7.0",
         "prettier": "3.5.3",
-        "ts-jest": "29.3.3",
+        "ts-jest": "29.3.4",
         "typescript": "5.8.3",
         "typescript-eslint": "8.32.1"
       },
@@ -688,13 +688,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
-      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1624,9 +1627,9 @@
       "peer": true
     },
     "node_modules/@types/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
+      "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1729,9 +1732,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3507,9 +3510,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "version": "1.23.10",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.10.tgz",
+      "integrity": "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3517,18 +3520,18 @@
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "data-view-buffer": "^1.0.2",
         "data-view-byte-length": "^1.0.2",
         "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
         "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
         "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
@@ -3544,13 +3547,13 @@
         "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
         "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
+        "is-weakref": "^1.1.1",
         "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.7",
         "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
+        "regexp.prototype.flags": "^1.5.4",
         "safe-array-concat": "^1.1.3",
         "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
@@ -3563,7 +3566,7 @@
         "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.18"
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4030,20 +4033,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {
@@ -4668,9 +4657,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6691,9 +6680,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.0.tgz",
+      "integrity": "sha512-bS8rPZurbAuHGAnApbM9d4h1wSoYqrOqkE+6a64KLMK9yWU7gJXBDDVklKQ3TPi9DRb85cRs6yXaC0+cjxRtRg==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -6705,7 +6694,7 @@
         "xtend": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -8445,9 +8434,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8554,9 +8543,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.3.tgz",
-      "integrity": "sha512-y6jLm19SL4GroiBmHwFK4dSHUfDNmOrJbRfp6QmDIlI9p5tT5Q8ItccB4pTIslCIqOZuQnBwpTR0bQ5eUMYwkw==",
+      "version": "29.3.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
+      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/main": "^0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/main": "0.13.0",
         "archiver": "7.0.1",
         "express": "5.1.0",
         "glob": "11.0.2",
@@ -1345,86 +1345,86 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-BsHZLlKp53sQmoj0JT/fjIelOi/GxuOLdn2gPjsby0mpTmapzY5keXtORM6kyx7H9zJYeeF//t8NKMOxKqezpw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.13.0.tgz",
+      "integrity": "sha512-PZ+FVJotKWgtoBvorqN+PLCuTBBbTCJTCss2P5C6n9r/ZAIcCgW7LDTFmRXNNNMJEri8JUVR0REvHaa92zVj2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.9.1"
+        "@noble/curves": "^1.8.2"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-ePzrr9e8U8NAz0bNoXkDaw3duzpRJPwTqhRm1qKdW04S8OJ2shKRHtY+PR++YiV9jBs7tLe1H98112nyvp1jlg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.13.0.tgz",
+      "integrity": "sha512-Qu60G05f821bEtp2yU+rJ7Xpe66GHDn9NdSPGrAn1EJH/iWplmVeLS1nSXzyGE28iPVPYNLcMX0edY/FejAhmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/node": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0",
+        "@matter/model": "0.13.0",
+        "@matter/node": "0.13.0",
+        "@matter/protocol": "0.13.0",
+        "@matter/types": "0.13.0"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/nodejs": "0.13.0"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-iNI2f6ek5rjYwYGE7L+e12kMVcH5GnSkpP9Q+HC+osLQiqaEmBjqsS6TvD+yUOnaVD6TIX+TIf1iuVJE6ACjhQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.13.0.tgz",
+      "integrity": "sha512-rcXu7OdMctlOGVOkClH6/+11ct6FMDSK2/Yu05+J7BJfohJY5mQbo0jnz8l0FPbwRrk5ADbqfAJ5jh/1OKHR2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-+fbBp71r+5m4G8OYh+WiYNeXKmUHi9JEkyDC1ocpfEpFYosjvuDWFOfwLmE3TS8RHk3dgcMf4FwhKg4mDkwfyw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.13.0.tgz",
+      "integrity": "sha512-HQkzpRnhAUfj9u2ijkT4qgyFzEfaNqyAxh+dgMpLKnbbGQoHTskJ/wEgkRRI7B0Q57mr6VJ5KgXYdbXUYA7xFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0",
+        "@matter/model": "0.13.0",
+        "@matter/protocol": "0.13.0",
+        "@matter/types": "0.13.0"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-80ZNSqMqLJCRXhxHGdq3U78C3JCXYpoQGOBElNJi7+SD+ktBudKaTZwsYGrvgPnlUFDj3ahHWwbaOvFrMCcxnQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.13.0.tgz",
+      "integrity": "sha512-ThWrLZJo7UH4Ebanf3gxkhe2p8vq4X3PxyRG+ICDRGPfzSAJZ3znh2hD/zdvcdyzQlSoXeLpFbLpTkJu7aRMHg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/node": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0",
+        "@matter/node": "0.13.0",
+        "@matter/protocol": "0.13.0",
+        "@matter/types": "0.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-r7YDwn79kv2I6SSZklhJ3vP7WsDroP6+zjn/3hatyog/8fRxcEm5Bk3JkxXlAgs8vDQ11DTmroDezXosBZSLZQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.13.0.tgz",
+      "integrity": "sha512-wFxU6+LG5ygzruOV5JF30hmLkk88hz8PqAMkQ6ow81ZvoDFBevsW0OyqxXMCNwYd/zmGXmvr3mpC0mi9/troHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0",
+        "@matter/model": "0.13.0",
+        "@matter/types": "0.13.0"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.14.0-alpha.0-20250521-979eda05d",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.14.0-alpha.0-20250521-979eda05d.tgz",
-      "integrity": "sha512-yCh/sm2uQ5Hmo5YS3oUq8ecpCyjIIb9luqHSPJQgtGm/cuf/VguQCeDqYiI6VNZxEY7QKrto3huvnbNFfLcZNg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.13.0.tgz",
+      "integrity": "sha512-8mH7hRC4MBSy4KUs8zb6uDTr0MfRYGtGBFq9t2uedlsiHA5lMUP3L1fitszoeCbpJh4EeqKHWSvF6RxWzKNueA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
-        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d"
+        "@matter/general": "0.13.0",
+        "@matter/model": "0.13.0"
       }
     },
     "node_modules/@noble/curves": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/main": "0.13.0",
+        "@matter/main": "^0.14.0-alpha.0-20250521-979eda05d",
         "archiver": "7.0.1",
         "express": "5.1.0",
         "glob": "11.0.2",
@@ -1345,86 +1345,86 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.13.0.tgz",
-      "integrity": "sha512-PZ+FVJotKWgtoBvorqN+PLCuTBBbTCJTCss2P5C6n9r/ZAIcCgW7LDTFmRXNNNMJEri8JUVR0REvHaa92zVj2Q==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-BsHZLlKp53sQmoj0JT/fjIelOi/GxuOLdn2gPjsby0mpTmapzY5keXtORM6kyx7H9zJYeeF//t8NKMOxKqezpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.8.2"
+        "@noble/curves": "^1.9.1"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.13.0.tgz",
-      "integrity": "sha512-Qu60G05f821bEtp2yU+rJ7Xpe66GHDn9NdSPGrAn1EJH/iWplmVeLS1nSXzyGE28iPVPYNLcMX0edY/FejAhmQ==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-ePzrr9e8U8NAz0bNoXkDaw3duzpRJPwTqhRm1qKdW04S8OJ2shKRHtY+PR++YiV9jBs7tLe1H98112nyvp1jlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.13.0",
-        "@matter/model": "0.13.0",
-        "@matter/node": "0.13.0",
-        "@matter/protocol": "0.13.0",
-        "@matter/types": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/node": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.13.0"
+        "@matter/nodejs": "0.14.0-alpha.0-20250521-979eda05d"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.13.0.tgz",
-      "integrity": "sha512-rcXu7OdMctlOGVOkClH6/+11ct6FMDSK2/Yu05+J7BJfohJY5mQbo0jnz8l0FPbwRrk5ADbqfAJ5jh/1OKHR2Q==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-iNI2f6ek5rjYwYGE7L+e12kMVcH5GnSkpP9Q+HC+osLQiqaEmBjqsS6TvD+yUOnaVD6TIX+TIf1iuVJE6ACjhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.13.0.tgz",
-      "integrity": "sha512-HQkzpRnhAUfj9u2ijkT4qgyFzEfaNqyAxh+dgMpLKnbbGQoHTskJ/wEgkRRI7B0Q57mr6VJ5KgXYdbXUYA7xFA==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-+fbBp71r+5m4G8OYh+WiYNeXKmUHi9JEkyDC1ocpfEpFYosjvuDWFOfwLmE3TS8RHk3dgcMf4FwhKg4mDkwfyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.13.0",
-        "@matter/model": "0.13.0",
-        "@matter/protocol": "0.13.0",
-        "@matter/types": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.13.0.tgz",
-      "integrity": "sha512-ThWrLZJo7UH4Ebanf3gxkhe2p8vq4X3PxyRG+ICDRGPfzSAJZ3znh2hD/zdvcdyzQlSoXeLpFbLpTkJu7aRMHg==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-80ZNSqMqLJCRXhxHGdq3U78C3JCXYpoQGOBElNJi7+SD+ktBudKaTZwsYGrvgPnlUFDj3ahHWwbaOvFrMCcxnQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.13.0",
-        "@matter/node": "0.13.0",
-        "@matter/protocol": "0.13.0",
-        "@matter/types": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/node": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/protocol": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.13.0.tgz",
-      "integrity": "sha512-wFxU6+LG5ygzruOV5JF30hmLkk88hz8PqAMkQ6ow81ZvoDFBevsW0OyqxXMCNwYd/zmGXmvr3mpC0mi9/troHg==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-r7YDwn79kv2I6SSZklhJ3vP7WsDroP6+zjn/3hatyog/8fRxcEm5Bk3JkxXlAgs8vDQ11DTmroDezXosBZSLZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.13.0",
-        "@matter/model": "0.13.0",
-        "@matter/types": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/types": "0.14.0-alpha.0-20250521-979eda05d"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.13.0.tgz",
-      "integrity": "sha512-8mH7hRC4MBSy4KUs8zb6uDTr0MfRYGtGBFq9t2uedlsiHA5lMUP3L1fitszoeCbpJh4EeqKHWSvF6RxWzKNueA==",
+      "version": "0.14.0-alpha.0-20250521-979eda05d",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.14.0-alpha.0-20250521-979eda05d.tgz",
+      "integrity": "sha512-yCh/sm2uQ5Hmo5YS3oUq8ecpCyjIIb9luqHSPJQgtGm/cuf/VguQCeDqYiI6VNZxEY7QKrto3huvnbNFfLcZNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.13.0",
-        "@matter/model": "0.13.0"
+        "@matter/general": "0.14.0-alpha.0-20250521-979eda05d",
+        "@matter/model": "0.14.0-alpha.0-20250521-979eda05d"
       }
     },
     "node_modules/@noble/curves": {
@@ -3451,9 +3451,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.155",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.155.tgz",
-      "integrity": "sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==",
+      "version": "1.5.157",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
+      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
       "dev": true,
       "license": "ISC"
     },
@@ -5568,9 +5568,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterbridge",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Matterbridge plugin manager for Matter",
   "author": "https://github.com/Luligu",
   "license": "Apache-2.0",
@@ -143,18 +143,18 @@
     "archiver": "7.0.1",
     "express": "5.1.0",
     "glob": "11.0.2",
-    "multer": "1.4.5-lts.2",
+    "multer": "2.0.0",
     "node-ansi-logger": "3.0.1",
     "node-persist-manager": "1.0.8",
     "ws": "8.18.2"
   },
   "devDependencies": {
-    "@eslint/js": "9.26.0",
+    "@eslint/js": "9.27.0",
     "@types/archiver": "6.0.3",
-    "@types/express": "5.0.1",
+    "@types/express": "5.0.2",
     "@types/jest": "29.5.14",
     "@types/multer": "1.4.12",
-    "@types/node": "22.15.18",
+    "@types/node": "22.15.21",
     "@types/ws": "8.18.1",
     "eslint-config-prettier": "10.1.5",
     "eslint-plugin-jest": "28.11.0",
@@ -164,7 +164,7 @@
     "eslint-plugin-react-hooks": "5.2.0",
     "jest": "29.7.0",
     "prettier": "3.5.3",
-    "ts-jest": "29.3.3",
+    "ts-jest": "29.3.4",
     "typescript": "5.8.3",
     "typescript-eslint": "8.32.1"
   }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,9 @@
     "deepCleanBuild": "npm run deepClean && npm install && npm run build && npm link && npx jest --clearCache",
     "runMeBeforePublish": "npm run lint && npm run format && npm run build && npm run test",
     "git:status": "git status && git branch -vv && git diff dev origin/dev",
-    "git:hardreset": "git fetch origin && git checkout dev && git reset --hard origin/dev",
+    "git:hardreset:main": "git fetch origin && git checkout main && git reset --hard origin/main",
+    "git:hardreset:dev": "git fetch origin && git checkout dev && git reset --hard origin/dev",
+    "git:hardreset:edge": "git fetch origin && git checkout edge && git reset --hard origin/edge",
     "prepublishOnly": "npm pkg delete devDependencies scripts && npm install --omit=dev && npm shrinkwrap",
     "prepublishOnlyProduction": "npm run cleanBuildProduction && npm pkg delete devDependencies scripts types && npx rimraf ./node_modules && npm install --omit=dev && npm shrinkwrap",
     "npmPack": "copy package.json package.log && npm run prepublishOnlyProduction && npm pack && copy package.log package.json && npm run deepCleanBuild",
@@ -139,7 +141,7 @@
     "install:jest": "npm install --save-dev jest ts-jest @types/jest eslint-plugin-jest && npm run test"
   },
   "dependencies": {
-    "@matter/main": "0.13.0",
+    "@matter/main": "^0.14.0-alpha.0-20250521-979eda05d",
     "archiver": "7.0.1",
     "express": "5.1.0",
     "glob": "11.0.2",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "install:jest": "npm install --save-dev jest ts-jest @types/jest eslint-plugin-jest && npm run test"
   },
   "dependencies": {
-    "@matter/main": "^0.14.0-alpha.0-20250521-979eda05d",
+    "@matter/main": "0.14.0-alpha.0-20250521-979eda05d",
     "archiver": "7.0.1",
     "express": "5.1.0",
     "glob": "11.0.2",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "install:jest": "npm install --save-dev jest ts-jest @types/jest eslint-plugin-jest && npm run test"
   },
   "dependencies": {
-    "@matter/main": "0.14.0-alpha.0-20250521-979eda05d",
+    "@matter/main": "0.13.0",
     "archiver": "7.0.1",
     "express": "5.1.0",
     "glob": "11.0.2",

--- a/src/frontend.ts
+++ b/src/frontend.ts
@@ -1424,7 +1424,7 @@ export class Frontend {
             }),
           );
         } else {
-          client.send(JSON.stringify({ id: data.id, method: data.method, src: 'Matterbridge', dst: data.src, error: 'Wrong parameter endpoint in /api/clusters' }));
+          client.send(JSON.stringify({ id: data.id, method: data.method, src: 'Matterbridge', dst: data.src, error: 'Endpoint not found in /api/clusters' }));
         }
       } else if (data.method === '/api/select' || data.method === '/api/select/devices') {
         if (!isValidString(data.params.plugin, 10)) {

--- a/src/frontend.websocket.test.ts
+++ b/src/frontend.websocket.test.ts
@@ -440,8 +440,15 @@ describe('Matterbridge frontend', () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringMatching(/^Received message from websocket client/));
   }, 60000);
 
+  test('Websocket API send /api/clusters with wrong endpoint', async () => {
+    const msg = await waitMessageId(++WS_ID, '/api/clusters', { id: WS_ID, dst: 'Matterbridge', src: 'Jest test', method: '/api/clusters', params: { plugin: 'matterbridge-mock1', endpoint: 15 } });
+    expect(msg.error).toBe('Endpoint not found in /api/clusters');
+    expect(msg.response).toBeUndefined();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringMatching(/^Received message from websocket client/));
+  }, 60000);
+
   test('Websocket API send /api/clusters', async () => {
-    const msg = await waitMessageId(++WS_ID, '/api/clusters', { id: WS_ID, dst: 'Matterbridge', src: 'Jest test', method: '/api/clusters', params: { plugin: 'matterbridge-mock1', endpoint: 2 } });
+    const msg = await waitMessageId(++WS_ID, '/api/clusters', { id: WS_ID, dst: 'Matterbridge', src: 'Jest test', method: '/api/clusters', params: { plugin: 'matterbridge-mock1', endpoint: 4 } });
     expect(msg.error).toBeUndefined();
     expect(msg.response).toBeDefined();
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringMatching(/^Received message from websocket client/));

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -40,7 +40,7 @@ let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
 let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
 let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
 let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = true;
+const debug = false; // Set to true to enable debug logging
 
 if (!debug) {
   loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
@@ -185,7 +185,19 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(device).toBeDefined();
     expect(device.lifecycle.isReady).toBeTruthy();
     expect(device.stateOf(OnOffServer).onOff).toBe(false);
-    expect(await invokeBehaviorCommand(device as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
+
+    await new Promise<void>((resolve) => {
+      const listener = (value: boolean) => {
+        if (value === true) {
+          (device as any).events.onOff.onOff$Changed.off(listener);
+          resolve();
+        }
+      };
+      (device as any).events.onOff.onOff$Changed.on(listener);
+      device.setStateOf(OnOffServer, { onOff: true });
+    });
+    // expect(await invokeBehaviorCommand(device as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(consoleLogSpy).toHaveBeenCalledWith('Device turned on');
     expect(device.stateOf(OnOffServer).onOff).toBe(false);
   });
@@ -243,12 +255,33 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(restartDevice).toBeDefined();
     if (!restartDevice) return;
     expect(restartDevice.stateOf(OnOffServer).onOff).toBe(false);
-    expect(await invokeBehaviorCommand(restartDevice as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
+
+    await new Promise<void>((resolve) => {
+      const listener = (value: boolean) => {
+        if (value === true) {
+          (restartDevice as any).events.onOff.onOff$Changed.off(listener);
+          resolve();
+        }
+      };
+      (restartDevice as any).events.onOff.onOff$Changed.on(listener);
+      restartDevice.setStateOf(OnOffServer, { onOff: true });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(mockMatterbridge.restartProcess).toHaveBeenCalled();
     expect(restartDevice.stateOf(OnOffServer).onOff).toBe(false);
 
     mockMatterbridge.restartMode = 'service';
-    expect(await invokeBehaviorCommand(restartDevice as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
+    await new Promise<void>((resolve) => {
+      const listener = (value: boolean) => {
+        if (value === true) {
+          (restartDevice as any).events.onOff.onOff$Changed.off(listener);
+          resolve();
+        }
+      };
+      (restartDevice as any).events.onOff.onOff$Changed.on(listener);
+      restartDevice.setStateOf(OnOffServer, { onOff: true });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(mockMatterbridge.shutdownProcess).toHaveBeenCalled();
     expect(restartDevice.stateOf(OnOffServer).onOff).toBe(false);
   });
@@ -258,9 +291,22 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(updateDevice).toBeDefined();
     if (!updateDevice) return;
     expect(updateDevice.stateOf(OnOffServer).onOff).toBe(false);
-    expect(await invokeBehaviorCommand(updateDevice as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
+
+    await new Promise<void>((resolve) => {
+      const listener = (value: boolean) => {
+        if (value === true) {
+          (updateDevice as any).events.onOff.onOff$Changed.off(listener);
+          resolve();
+        }
+      };
+      (updateDevice as any).events.onOff.onOff$Changed.on(listener);
+      updateDevice.setStateOf(OnOffServer, { onOff: true });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(mockMatterbridge.updateProcess).toHaveBeenCalled();
     expect(updateDevice.stateOf(OnOffServer).onOff).toBe(false);
+
+    // expect(await invokeBehaviorCommand(updateDevice as unknown as MatterbridgeEndpoint, OnOffServer, 'on')).toBe(true);
   });
 
   test('add all the virtual devices with shelly parameter', async () => {

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -18,7 +18,7 @@ const { getShelly, postShelly } = await import('./shelly.js');
 (getShelly as jest.MockedFunction<(api: string, timeout?: number) => Promise<void>>).mockResolvedValue();
 (postShelly as jest.MockedFunction<(api: string, data: any, timeout?: number) => Promise<void>>).mockResolvedValue();
 
-import { DeviceTypeId, VendorId, ServerNode, Endpoint, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel, Environment, EndpointServer } from '@matter/main';
+import { DeviceTypeId, VendorId, ServerNode, Endpoint, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel, Environment } from '@matter/main';
 import { AggregatorEndpoint, RootEndpoint } from '@matter/main/endpoints';
 import { BridgedDeviceBasicInformationServer, OnOffServer } from '@matter/main/behaviors';
 import { logEndpoint, MdnsService } from '@matter/main/protocol';
@@ -156,7 +156,6 @@ describe('Matterbridge Helpers', () => {
 
   test('log the server node', async () => {
     expect(server).toBeDefined();
-    // logEndpoint(EndpointServer.forEndpoint(server));
   });
 
   test('add a light virtual device', async () => {
@@ -171,7 +170,6 @@ describe('Matterbridge Helpers', () => {
     expect(device.stateOf(BridgedDeviceBasicInformationServer).nodeLabel).toBe('Test Device');
     expect(device.stateOf(OnOffServer).onOff).toBe(false);
     expect(aggregator.parts.has('TestDevice:light')).toBeTruthy();
-    // logEndpoint(EndpointServer.forEndpoint(device));
   });
 
   test('send command to the virtual device', async () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -68,7 +68,7 @@ export async function addVirtualDevice(aggregatorEndpoint: Endpoint<AggregatorEn
   }
   const device = new Endpoint(deviceType, {
     id: name.replaceAll(' ', '') + ':' + type,
-    bridgedDeviceBasicInformation: { nodeLabel: name },
+    bridgedDeviceBasicInformation: { nodeLabel: name.slice(0, 32) },
     onOff: { onOff: false, startUpOnOff: OnOff.StartUpOnOff.Off },
   });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -73,11 +73,17 @@ export async function addVirtualDevice(aggregatorEndpoint: Endpoint<AggregatorEn
   });
 
   // Set up an event listener for when the `onOff` state changes.
-  device.events.onOff.onOff$Changed.on(async (value) => {
+  device.events.onOff.onOff$Changed.on((value) => {
     // If the `onOff` state becomes true, turn off the virtual device and execute the callback.
     if (value) {
-      await device.setStateOf(OnOffBaseServer, { onOff: false });
       callback();
+      process.nextTick(async () => {
+        try {
+          await device.setStateOf(OnOffBaseServer, { onOff: false });
+        } catch (_error) {
+          // Not necessary to handle the error
+        }
+      });
     }
   });
 

--- a/src/matter/export.ts
+++ b/src/matter/export.ts
@@ -18,4 +18,4 @@ export {
   SwitchesTag,
 } from '@matter/main';
 export { AttributeElement, ClusterElement, ClusterModel, CommandElement, EventElement, FieldElement } from '@matter/main/model';
-export { logEndpoint, MdnsService, Val } from '@matter/main/protocol';
+export { MdnsService, Val } from '@matter/main/protocol';

--- a/src/matterbridge.ts
+++ b/src/matterbridge.ts
@@ -315,8 +315,8 @@ export class Matterbridge extends EventEmitter {
 
   /**
    * Call cleanup().
-   * @deprecated This method is deprecated and is only used for jest tests.
    *
+   * @deprecated This method is deprecated and is ONLY used for jest tests.
    */
   async destroyInstance() {
     this.log.info(`Destroy instance...`);

--- a/src/matterbridgeBehaviors.ts
+++ b/src/matterbridgeBehaviors.ts
@@ -167,6 +167,10 @@ export class MatterbridgeServerDevice {
     this.log.info(`Setting cover lift percentage to ${liftPercent100thsValue} (endpoint ${this.endpointId}.${this.endpointNumber})`);
     this.commandHandler.executeHandler('goToLiftPercentage', { request: { liftPercent100thsValue }, attributes: {}, endpoint: { number: this.endpointNumber, uniqueStorageKey: this.endpointId } } as any);
   }
+  goToTiltPercentage({ tiltPercent100thsValue }: WindowCovering.GoToTiltPercentageRequest) {
+    this.log.info(`Setting cover tilt percentage to ${tiltPercent100thsValue} (endpoint ${this.endpointId}.${this.endpointNumber})`);
+    this.commandHandler.executeHandler('goToTiltPercentage', { request: { tiltPercent100thsValue }, attributes: {}, endpoint: { number: this.endpointNumber, uniqueStorageKey: this.endpointId } } as any);
+  }
 
   lockDoor() {
     this.log.info(`Locking door (endpoint ${this.endpointId}.${this.endpointNumber})`);
@@ -355,7 +359,7 @@ export class MatterbridgeColorControlServer extends ColorControlServer.with(Colo
   }
 }
 
-export class MatterbridgeWindowCoveringServer extends WindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift) {
+export class MatterbridgeLiftWindowCoveringServer extends WindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift) {
   override upOrOpen(): MaybePromise {
     const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
     device.upOrOpen();
@@ -379,6 +383,36 @@ export class MatterbridgeWindowCoveringServer extends WindowCoveringServer.with(
     device.goToLiftPercentage({ liftPercent100thsValue });
     device.log.debug(`MatterbridgeWindowCoveringServer: goToLiftPercentage with ${liftPercent100thsValue}`);
     super.goToLiftPercentage({ liftPercent100thsValue });
+  }
+  override async handleMovement(type: MovementType, reversed: boolean, direction: MovementDirection, targetPercent100ths?: number) {
+    // Do nothing here, as the device will handle the movement
+  }
+}
+
+export class MatterbridgeTiltWindowCoveringServer extends WindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt) {
+  override upOrOpen(): MaybePromise {
+    const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
+    device.upOrOpen();
+    device.log.debug(`MatterbridgeTiltWindowCoveringServer: upOrOpen called`);
+    super.upOrOpen();
+  }
+  override downOrClose(): MaybePromise {
+    const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
+    device.downOrClose();
+    device.log.debug(`MatterbridgeTiltWindowCoveringServer: downOrClose called`);
+    super.downOrClose();
+  }
+  override stopMotion(): MaybePromise {
+    const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
+    device.stopMotion();
+    device.log.debug(`MatterbridgeTiltWindowCoveringServer: stopMotion called`);
+    super.stopMotion();
+  }
+  override goToTiltPercentage({ tiltPercent100thsValue }: WindowCovering.GoToTiltPercentageRequest): MaybePromise {
+    const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
+    device.goToTiltPercentage({ tiltPercent100thsValue });
+    device.log.debug(`MatterbridgeTiltWindowCoveringServer: goToTiltPercentage with ${tiltPercent100thsValue}`);
+    super.goToTiltPercentage({ tiltPercent100thsValue });
   }
   override async handleMovement(type: MovementType, reversed: boolean, direction: MovementDirection, targetPercent100ths?: number) {
     // Do nothing here, as the device will handle the movement

--- a/src/matterbridgeBehaviors.ts
+++ b/src/matterbridgeBehaviors.ts
@@ -389,29 +389,35 @@ export class MatterbridgeLiftWindowCoveringServer extends WindowCoveringServer.w
   }
 }
 
-export class MatterbridgeTiltWindowCoveringServer extends WindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt) {
+export class MatterbridgeLiftTiltWindowCoveringServer extends WindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift, WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt) {
   override upOrOpen(): MaybePromise {
     const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
     device.upOrOpen();
-    device.log.debug(`MatterbridgeTiltWindowCoveringServer: upOrOpen called`);
+    device.log.debug(`MatterbridgeLiftTiltWindowCoveringServer: upOrOpen called`);
     super.upOrOpen();
   }
   override downOrClose(): MaybePromise {
     const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
     device.downOrClose();
-    device.log.debug(`MatterbridgeTiltWindowCoveringServer: downOrClose called`);
+    device.log.debug(`MatterbridgeLiftTiltWindowCoveringServer: downOrClose called`);
     super.downOrClose();
   }
   override stopMotion(): MaybePromise {
     const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
     device.stopMotion();
-    device.log.debug(`MatterbridgeTiltWindowCoveringServer: stopMotion called`);
+    device.log.debug(`MatterbridgeLiftTiltWindowCoveringServer: stopMotion called`);
     super.stopMotion();
+  }
+  override goToLiftPercentage({ liftPercent100thsValue }: WindowCovering.GoToLiftPercentageRequest): MaybePromise {
+    const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
+    device.goToLiftPercentage({ liftPercent100thsValue });
+    device.log.debug(`MatterbridgeLiftTiltWindowCoveringServer: goToLiftPercentage with ${liftPercent100thsValue}`);
+    super.goToLiftPercentage({ liftPercent100thsValue });
   }
   override goToTiltPercentage({ tiltPercent100thsValue }: WindowCovering.GoToTiltPercentageRequest): MaybePromise {
     const device = this.agent.get(MatterbridgeServer).state.deviceCommand;
     device.goToTiltPercentage({ tiltPercent100thsValue });
-    device.log.debug(`MatterbridgeTiltWindowCoveringServer: goToTiltPercentage with ${tiltPercent100thsValue}`);
+    device.log.debug(`MatterbridgeLiftTiltWindowCoveringServer: goToTiltPercentage with ${tiltPercent100thsValue}`);
     super.goToTiltPercentage({ tiltPercent100thsValue });
   }
   override async handleMovement(type: MovementType, reversed: boolean, direction: MovementDirection, targetPercent100ths?: number) {

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -445,16 +445,16 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths')).toBe(50);
   });
 
-  test('createDefaultTiltWindowCoveringClusterServer', async () => {
+  test('createDefaultLiftTiltWindowCoveringClusterServer', async () => {
     const device = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'TiltScreen' });
     expect(device).toBeDefined();
     device.createDefaultIdentifyClusterServer();
-    device.createDefaultTiltWindowCoveringClusterServer();
+    device.createDefaultLiftTiltWindowCoveringClusterServer();
     expect(device.hasAttributeServer('WindowCovering', 'type')).toBe(true);
     expect(device.hasAttributeServer('WindowCovering', 'operationalStatus')).toBe(true);
     expect(device.hasAttributeServer('WindowCovering', 'mode')).toBe(true);
-    expect(device.hasAttributeServer('WindowCovering', 'targetPositionLiftPercent100ths')).toBe(false);
-    expect(device.hasAttributeServer('WindowCovering', 'currentPositionLiftPercent100ths')).toBe(false);
+    expect(device.hasAttributeServer('WindowCovering', 'targetPositionLiftPercent100ths')).toBe(true);
+    expect(device.hasAttributeServer('WindowCovering', 'currentPositionLiftPercent100ths')).toBe(true);
     expect(device.hasAttributeServer('WindowCovering', 'targetPositionTiltPercent100ths')).toBe(true);
     expect(device.hasAttributeServer('WindowCovering', 'currentPositionTiltPercent100ths')).toBe(true);
 
@@ -465,14 +465,17 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths'));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Stopped);
     await device.setWindowCoveringCurrentTargetStatus(50, 50, WindowCovering.MovementStatus.Closing);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionTiltPercent100ths: 50, targetPositionTiltPercent100ths: 50 and operationalStatus: 2.`));
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionLiftPercent100ths: 50, targetPositionLiftPercent100ths: 50 and operationalStatus: 2.`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Closing);
     await device.setWindowCoveringStatus(WindowCovering.MovementStatus.Opening);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering operationalStatus: 1`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Opening);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Get WindowCovering operationalStatus: 1`));
-    await device.setWindowCoveringTargetAndCurrentPosition(50);
+    await device.setWindowCoveringTargetAndCurrentPosition(50, 50);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionLiftPercent100ths: 50 and targetPositionLiftPercent100ths: 50.`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionTiltPercent100ths: 50 and targetPositionTiltPercent100ths: 50.`));
+    expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')).toBe(50);
+    expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths')).toBe(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths')).toBe(50);
   });

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -91,6 +91,9 @@ import {
 } from './matterbridgeDeviceTypes.js';
 import { updateAttribute } from './matterbridgeEndpointHelpers.js';
 
+const MATTER_PORT = 6002;
+const HOMEDIR = 'EndpointDefault';
+
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
 let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
@@ -116,9 +119,9 @@ if (!debug) {
 }
 
 // Cleanup the matter environment
-rmSync(path.join('test', 'EndpointDefault'), { recursive: true, force: true });
+rmSync(path.join('test', HOMEDIR), { recursive: true, force: true });
 
-describe('MatterbridgeEndpointDefault', () => {
+describe('Matterbridge ' + HOMEDIR, () => {
   let matterbridge: Matterbridge;
   let device: MatterbridgeEndpoint;
 
@@ -146,7 +149,7 @@ describe('MatterbridgeEndpointDefault', () => {
 
   beforeAll(async () => {
     // Create a MatterbridgeEdge instance
-    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-homedir', path.join('test', 'EndpointDefault'), '-bridge', '-logger', 'info', '-matterlogger', 'info'];
+    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-port', MATTER_PORT.toString(), '-homedir', path.join('test', HOMEDIR), '-bridge', '-logger', 'info', '-matterlogger', 'info'];
     matterbridge = await Matterbridge.loadInstance(true);
     await waitForOnline();
   }, 30000);

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -149,7 +149,7 @@ describe('Matterbridge ' + HOMEDIR, () => {
 
   beforeAll(async () => {
     // Create a MatterbridgeEdge instance
-    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-port', MATTER_PORT.toString(), '-homedir', path.join('test', HOMEDIR), '-bridge', '-logger', 'info', '-matterlogger', 'info'];
+    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-port', MATTER_PORT.toString(), '-homedir', path.join('test', HOMEDIR), '-bridge', '-logger', 'debug', '-matterlogger', 'debug'];
     matterbridge = await Matterbridge.loadInstance(true);
     await waitForOnline();
   }, 30000);
@@ -415,7 +415,7 @@ describe('Matterbridge ' + HOMEDIR, () => {
   });
 
   test('createDefaultWindowCoveringClusterServer', async () => {
-    const device = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'Screen' });
+    const device = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'LiftScreen' });
     expect(device).toBeDefined();
     device.createDefaultIdentifyClusterServer();
     device.createDefaultWindowCoveringClusterServer();
@@ -439,6 +439,33 @@ describe('Matterbridge ' + HOMEDIR, () => {
     await device.setWindowCoveringTargetAndCurrentPosition(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')).toBe(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths')).toBe(50);
+  });
+
+  test('createDefaultTiltWindowCoveringClusterServer', async () => {
+    const device = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'TiltScreen' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultTiltWindowCoveringClusterServer();
+    expect(device.hasAttributeServer('WindowCovering', 'type')).toBe(true);
+    expect(device.hasAttributeServer('WindowCovering', 'operationalStatus')).toBe(true);
+    expect(device.hasAttributeServer('WindowCovering', 'mode')).toBe(true);
+    expect(device.hasAttributeServer('WindowCovering', 'targetPositionLiftPercent100ths')).toBe(false);
+    expect(device.hasAttributeServer('WindowCovering', 'currentPositionLiftPercent100ths')).toBe(false);
+    expect(device.hasAttributeServer('WindowCovering', 'targetPositionTiltPercent100ths')).toBe(true);
+    expect(device.hasAttributeServer('WindowCovering', 'currentPositionTiltPercent100ths')).toBe(true);
+
+    await add(device);
+
+    await device.setWindowCoveringTargetAsCurrentAndStopped();
+    expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths'));
+    expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Stopped);
+    await device.setWindowCoveringCurrentTargetStatus(50, 50, WindowCovering.MovementStatus.Closing);
+    expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Closing);
+    await device.setWindowCoveringStatus(WindowCovering.MovementStatus.Opening);
+    expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Opening);
+    await device.setWindowCoveringTargetAndCurrentPosition(50);
+    expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(50);
+    expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths')).toBe(50);
   });
 
   test('createDefaultThermostatClusterServer', async () => {

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -91,8 +91,7 @@ import {
   waterLeakDetector,
   waterValve,
 } from './matterbridgeDeviceTypes.js';
-import { capitalizeFirstLetter, updateAttribute } from './matterbridgeEndpointHelpers.js';
-import { log } from 'node:console';
+import { updateAttribute } from './matterbridgeEndpointHelpers.js';
 
 const MATTER_PORT = 6002;
 const HOMEDIR = 'EndpointDefault';

--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -90,6 +90,7 @@ import {
   waterValve,
 } from './matterbridgeDeviceTypes.js';
 import { updateAttribute } from './matterbridgeEndpointHelpers.js';
+import { log } from 'node:console';
 
 const MATTER_PORT = 6002;
 const HOMEDIR = 'EndpointDefault';
@@ -430,13 +431,18 @@ describe('Matterbridge ' + HOMEDIR, () => {
     await add(device);
 
     await device.setWindowCoveringTargetAsCurrentAndStopped();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionLiftPercent100ths and targetPositionLiftPercent100ths to 0 and operationalStatus to Stopped.`));
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')).toBe(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths'));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Stopped);
     await device.setWindowCoveringCurrentTargetStatus(50, 50, WindowCovering.MovementStatus.Closing);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionLiftPercent100ths: 50, targetPositionLiftPercent100ths: 50 and operationalStatus: 2.`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Closing);
     await device.setWindowCoveringStatus(WindowCovering.MovementStatus.Opening);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering operationalStatus: 1`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Opening);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Get WindowCovering operationalStatus: 1`));
     await device.setWindowCoveringTargetAndCurrentPosition(50);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionLiftPercent100ths: 50 and targetPositionLiftPercent100ths: 50.`));
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')).toBe(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths')).toBe(50);
   });
@@ -457,13 +463,18 @@ describe('Matterbridge ' + HOMEDIR, () => {
     await add(device);
 
     await device.setWindowCoveringTargetAsCurrentAndStopped();
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionTiltPercent100ths and targetPositionTiltPercent100ths to 0 and operationalStatus to Stopped.`));
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths'));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Stopped);
     await device.setWindowCoveringCurrentTargetStatus(50, 50, WindowCovering.MovementStatus.Closing);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionTiltPercent100ths: 50, targetPositionTiltPercent100ths: 50 and operationalStatus: 2.`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Closing);
     await device.setWindowCoveringStatus(WindowCovering.MovementStatus.Opening);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering operationalStatus: 1`));
     expect(device.getWindowCoveringStatus()).toBe(WindowCovering.MovementStatus.Opening);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Get WindowCovering operationalStatus: 1`));
     await device.setWindowCoveringTargetAndCurrentPosition(50);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`Set WindowCovering currentPositionTiltPercent100ths: 50 and targetPositionTiltPercent100ths: 50.`));
     expect(device.getAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths')).toBe(50);
     expect(device.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths')).toBe(50);
   });

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -83,7 +83,7 @@ import {
   MatterbridgeThermostatServer,
   MatterbridgeValveConfigurationAndControlServer,
   MatterbridgeLiftWindowCoveringServer,
-  MatterbridgeTiltWindowCoveringServer,
+  MatterbridgeLiftTiltWindowCoveringServer,
 } from './matterbridgeBehaviors.js';
 import { Matterbridge } from './matterbridge.js';
 import {
@@ -141,7 +141,7 @@ describe('Matterbridge ' + HOMEDIR, () => {
   let aggregator: Endpoint<AggregatorEndpoint>;
   let light: MatterbridgeEndpoint;
   let coverLift: MatterbridgeEndpoint;
-  let coverTilt: MatterbridgeEndpoint;
+  let coverLiftTilt: MatterbridgeEndpoint;
   let lock: MatterbridgeEndpoint;
   let fan: MatterbridgeEndpoint;
   let thermostat: MatterbridgeEndpoint;
@@ -222,11 +222,11 @@ describe('Matterbridge ' + HOMEDIR, () => {
   });
 
   test('create a cover tilt device', async () => {
-    coverTilt = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'WindowCoverTilt' });
-    coverTilt.createDefaultTiltWindowCoveringClusterServer();
-    coverTilt.addRequiredClusterServers();
-    expect(coverTilt).toBeDefined();
-    expect(coverTilt.id).toBe('WindowCoverTilt');
+    coverLiftTilt = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'WindowCoverTilt' });
+    coverLiftTilt.createDefaultLiftTiltWindowCoveringClusterServer();
+    coverLiftTilt.addRequiredClusterServers();
+    expect(coverLiftTilt).toBeDefined();
+    expect(coverLiftTilt.id).toBe('WindowCoverTilt');
   });
 
   test('create a lock device', async () => {
@@ -385,7 +385,7 @@ describe('Matterbridge ' + HOMEDIR, () => {
   });
 
   test('add tilt coverDevice device to serverNode', async () => {
-    expect(await server.add(coverTilt)).toBeDefined();
+    expect(await server.add(coverLiftTilt)).toBeDefined();
   });
 
   test('add lockDevice device to serverNode', async () => {
@@ -710,24 +710,26 @@ describe('Matterbridge ' + HOMEDIR, () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Setting cover lift percentage to 5000 (endpoint ${coverLift.id}.${coverLift.number})`);
   });
 
-  test('invoke MatterbridgeTiltWindowCoveringServer commands', async () => {
-    expect(coverTilt.behaviors.has(WindowCoveringServer)).toBeTruthy();
-    expect(coverTilt.behaviors.has(MatterbridgeTiltWindowCoveringServer)).toBeTruthy();
-    expect(coverTilt.behaviors.elementsOf(MatterbridgeTiltWindowCoveringServer).commands.has('upOrOpen')).toBeTruthy();
-    expect(coverTilt.behaviors.elementsOf(MatterbridgeTiltWindowCoveringServer).commands.has('downOrClose')).toBeTruthy();
-    expect(coverTilt.behaviors.elementsOf(MatterbridgeTiltWindowCoveringServer).commands.has('stopMotion')).toBeTruthy();
-    expect(coverTilt.behaviors.elementsOf(MatterbridgeTiltWindowCoveringServer).commands.has('goToLiftPercentage')).toBeFalsy();
-    expect(coverTilt.behaviors.elementsOf(MatterbridgeTiltWindowCoveringServer).commands.has('goToTiltPercentage')).toBeTruthy();
-    expect((coverTilt.stateOf(MatterbridgeTiltWindowCoveringServer) as any).acceptedCommandList).toEqual([0, 1, 2, 8]);
-    expect((coverTilt.stateOf(MatterbridgeTiltWindowCoveringServer) as any).generatedCommandList).toEqual([]);
-    await invokeBehaviorCommand(coverTilt, 'windowCovering', 'upOrOpen');
-    await invokeBehaviorCommand(coverTilt, 'windowCovering', 'downOrClose');
-    await invokeBehaviorCommand(coverTilt, 'windowCovering', 'stopMotion');
-    await invokeBehaviorCommand(coverTilt, 'windowCovering', 'goToTiltPercentage', { tiltPercent100thsValue: 5000 });
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Opening cover (endpoint ${coverTilt.id}.${coverTilt.number})`);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Closing cover (endpoint ${coverTilt.id}.${coverTilt.number})`);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Stopping cover (endpoint ${coverTilt.id}.${coverTilt.number})`);
-    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Setting cover tilt percentage to 5000 (endpoint ${coverTilt.id}.${coverTilt.number})`);
+  test('invoke MatterbridgeLiftTiltWindowCoveringServer commands', async () => {
+    expect(coverLiftTilt.behaviors.has(WindowCoveringServer)).toBeTruthy();
+    expect(coverLiftTilt.behaviors.has(MatterbridgeLiftTiltWindowCoveringServer)).toBeTruthy();
+    expect(coverLiftTilt.behaviors.elementsOf(MatterbridgeLiftTiltWindowCoveringServer).commands.has('upOrOpen')).toBeTruthy();
+    expect(coverLiftTilt.behaviors.elementsOf(MatterbridgeLiftTiltWindowCoveringServer).commands.has('downOrClose')).toBeTruthy();
+    expect(coverLiftTilt.behaviors.elementsOf(MatterbridgeLiftTiltWindowCoveringServer).commands.has('stopMotion')).toBeTruthy();
+    expect(coverLiftTilt.behaviors.elementsOf(MatterbridgeLiftTiltWindowCoveringServer).commands.has('goToLiftPercentage')).toBeTruthy();
+    expect(coverLiftTilt.behaviors.elementsOf(MatterbridgeLiftTiltWindowCoveringServer).commands.has('goToTiltPercentage')).toBeTruthy();
+    expect((coverLiftTilt.stateOf(MatterbridgeLiftTiltWindowCoveringServer) as any).acceptedCommandList).toEqual([0, 1, 2, 5, 8]);
+    expect((coverLiftTilt.stateOf(MatterbridgeLiftTiltWindowCoveringServer) as any).generatedCommandList).toEqual([]);
+    await invokeBehaviorCommand(coverLiftTilt, 'windowCovering', 'upOrOpen');
+    await invokeBehaviorCommand(coverLiftTilt, 'windowCovering', 'downOrClose');
+    await invokeBehaviorCommand(coverLiftTilt, 'windowCovering', 'stopMotion');
+    await invokeBehaviorCommand(coverLiftTilt, 'windowCovering', 'goToLiftPercentage', { liftPercent100thsValue: 5000 });
+    await invokeBehaviorCommand(coverLiftTilt, 'windowCovering', 'goToTiltPercentage', { tiltPercent100thsValue: 5000 });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Opening cover (endpoint ${coverLiftTilt.id}.${coverLiftTilt.number})`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Closing cover (endpoint ${coverLiftTilt.id}.${coverLiftTilt.number})`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Stopping cover (endpoint ${coverLiftTilt.id}.${coverLiftTilt.number})`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Setting cover lift percentage to 5000 (endpoint ${coverLiftTilt.id}.${coverLiftTilt.number})`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Setting cover tilt percentage to 5000 (endpoint ${coverLiftTilt.id}.${coverLiftTilt.number})`);
   });
 
   test('invoke MatterbridgeDoorLockServer commands', async () => {

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -26,7 +26,7 @@ import {
   WaterHeaterMode,
 } from '@matter/main/clusters';
 import { AggregatorEndpoint } from '@matter/main/endpoints';
-import { logEndpoint, MdnsService } from '@matter/main/protocol';
+import { MdnsService } from '@matter/main/protocol';
 import { ContactSensorDevice, OnOffPlugInUnitDevice } from '@matter/node/devices';
 import {
   BooleanStateConfigurationServer,
@@ -106,13 +106,16 @@ import { getAttributeId, getClusterId, invokeBehaviorCommand } from './matterbri
 import { RoboticVacuumCleaner } from './roboticVacuumCleaner.js';
 import { WaterHeater } from './waterHeater.js';
 
+const MATTER_PORT = 6001;
+const HOMEDIR = 'EndpointMatterJs';
+
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
 let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
 let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
 let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
 let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false;
+const debug = false; // Set to true to enable debug logging
 
 if (!debug) {
   loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
@@ -130,7 +133,7 @@ if (!debug) {
   consoleErrorSpy = jest.spyOn(console, 'error');
 }
 
-describe('MatterbridgeEndpointMatterJs', () => {
+describe('Matterbridge ' + HOMEDIR, () => {
   let matterbridge: Matterbridge;
   let context: StorageContext;
   let server: ServerNode<ServerNode.RootEndpoint>;
@@ -152,16 +155,16 @@ describe('MatterbridgeEndpointMatterJs', () => {
 
   beforeAll(async () => {
     // Cleanup the matter environment
-    rmSync(path.join('test', 'EndpointMatterJs'), { recursive: true, force: true });
+    rmSync(path.join('test', HOMEDIR), { recursive: true, force: true });
 
     // Create a MatterbridgeEdge instance
     matterbridge = await Matterbridge.loadInstance(false);
     matterbridge.log = new AnsiLogger({ logName: 'Matterbridge', logTimestampFormat: TimestampFormat.TIME_MILLIS, logLevel: LogLevel.DEBUG });
-    matterbridge.matterbridgeDirectory = path.join('test', 'EndpointMatterJs');
+    matterbridge.matterbridgeDirectory = path.join('test', HOMEDIR);
     // Setup matter environment
     matterbridge.environment.vars.set('log.level', MatterLogLevel.INFO);
     matterbridge.environment.vars.set('log.format', MatterLogFormat.ANSI);
-    matterbridge.environment.vars.set('path.root', path.join('test', 'EndpointMatterJs'));
+    matterbridge.environment.vars.set('path.root', path.join('test', HOMEDIR));
     matterbridge.environment.vars.set('runtime.signals', false);
     matterbridge.environment.vars.set('runtime.exitcode', false);
     await (matterbridge as any).startMatterStorage();
@@ -184,19 +187,18 @@ describe('MatterbridgeEndpointMatterJs', () => {
   const deviceType = extendedColorLight;
 
   test('create a context for server node', async () => {
-    expect(matterbridge.environment.vars.get('path.root')).toBe(path.join('test', 'EndpointMatterJs'));
+    expect(matterbridge.environment.vars.get('path.root')).toBe(path.join('test', HOMEDIR));
     context = await (matterbridge as any).createServerNodeContext('Matterbridge', deviceType.name, DeviceTypeId(deviceType.code), VendorId(0xfff1), 'Matterbridge', 0x8000, 'Matterbridge ' + deviceType.name.replace('MA-', ''));
     expect(context).toBeDefined();
   });
 
   test('create the server node', async () => {
-    server = await (matterbridge as any).createServerNode(context);
+    server = await (matterbridge as any).createServerNode(context, MATTER_PORT);
     expect(server).toBeDefined();
   });
 
   test('create a onOffLight device', async () => {
     light = new MatterbridgeEndpoint(deviceType, { uniqueStorageKey: 'OnOffLight', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Switch1' }] });
-    // light.addRequiredClusterServers();
     expect(light).toBeDefined();
     expect(light.id).toBe('OnOffLight');
     expect(light.type.name).toBe(deviceType.name.replace('-', '_'));
@@ -205,7 +207,7 @@ describe('MatterbridgeEndpointMatterJs', () => {
     expect(light.type.deviceRevision).toBe(deviceType.revision);
   });
 
-  test('create a covert device', async () => {
+  test('create a cover device', async () => {
     cover = new MatterbridgeEndpoint(coverDevice, { uniqueStorageKey: 'WindowCover' });
     cover.addRequiredClusterServers();
     expect(cover).toBeDefined();
@@ -313,9 +315,15 @@ describe('MatterbridgeEndpointMatterJs', () => {
     expect(light.behaviors.supported.descriptor).toBeDefined();
     expect(light.behaviors.has(DescriptorBehavior)).toBeTruthy();
     expect(light.behaviors.has(DescriptorServer)).toBeTruthy();
+    expect(light.hasClusterServer(DescriptorBehavior)).toBeTruthy();
+    expect(light.hasClusterServer(DescriptorServer)).toBeTruthy();
     expect(light.hasClusterServer(DescriptorCluster)).toBeTruthy();
+    expect(light.hasClusterServer(Descriptor.Cluster)).toBeTruthy();
     expect(light.hasClusterServer(DescriptorCluster.id)).toBeTruthy();
+    expect(light.hasClusterServer(Descriptor.Cluster.id)).toBeTruthy();
     expect(light.hasClusterServer(DescriptorCluster.name)).toBeTruthy();
+    expect(light.hasClusterServer('Descriptor')).toBeTruthy();
+    expect(light.hasClusterServer('descriptor')).toBeTruthy();
     // consoleWarnSpy?.mockRestore();
     // console.warn(device.behaviors.optionsFor(DescriptorBehavior));
 
@@ -357,7 +365,7 @@ describe('MatterbridgeEndpointMatterJs', () => {
     expect(light.hasClusterServer(OnOffCluster)).toBe(true);
   });
 
-  test('add rollerDevice device to serverNode', async () => {
+  test('add coverDevice device to serverNode', async () => {
     expect(await server.add(cover)).toBeDefined();
   });
 
@@ -395,16 +403,25 @@ describe('MatterbridgeEndpointMatterJs', () => {
 
   test('getClusterId and getAttributeId of onOffLight device behaviors', async () => {
     expect(light).toBeDefined();
-    expect(getClusterId(light, 'onOff')).toBe(6);
-    expect(getClusterId(light, 'OnOff')).toBe(6);
+    expect(getClusterId(light, 'onOff')).toBe(0x6);
+    expect(getClusterId(light, 'OnOff')).toBe(0x6);
+
+    expect(getClusterId(light, 'levelControl')).toBe(0x8);
+    expect(getClusterId(light, 'LevelControl')).toBe(0x8);
+
     expect(getAttributeId(light, 'onOff', 'OnOff')).toBe(0);
     expect(getAttributeId(light, 'OnOff', 'OnOff')).toBe(0);
     expect(getAttributeId(light, 'onOff', 'onOff')).toBe(0);
     expect(getAttributeId(light, 'OnOff', 'onOff')).toBe(0);
+
+    expect(getAttributeId(light, 'onOff', 'OnTime')).toBe(0x4001);
+    expect(getAttributeId(light, 'OnOff', 'OnTime')).toBe(0x4001);
+    expect(getAttributeId(light, 'onOff', 'onTime')).toBe(0x4001);
+    expect(getAttributeId(light, 'OnOff', 'onTime')).toBe(0x4001);
   });
 
   test('add deviceType to onOffPlugin without tagList', async () => {
-    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer, OccupancySensingServer), {
+    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer, OccupancySensingServer.with(OccupancySensing.Feature.PassiveInfrared)), {
       id: 'OnOffPlugin1',
       identify: {
         identifyTime: 0,
@@ -436,7 +453,7 @@ describe('MatterbridgeEndpointMatterJs', () => {
   });
 
   test('add deviceType to onOffPlugin with tagList', async () => {
-    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer.with(Descriptor.Feature.TagList), OccupancySensingServer), {
+    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer.with(Descriptor.Feature.TagList), OccupancySensingServer.with(OccupancySensing.Feature.PassiveInfrared)), {
       id: 'OnOffPlugin2',
       identify: {
         identifyTime: 0,
@@ -472,7 +489,7 @@ describe('MatterbridgeEndpointMatterJs', () => {
   });
 
   test('add deviceType to onOffPlugin in the costructor', async () => {
-    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer.with(Descriptor.Feature.TagList), OccupancySensingServer, IlluminanceMeasurementServer), {
+    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(DescriptorServer.with(Descriptor.Feature.TagList), OccupancySensingServer.with(OccupancySensing.Feature.PassiveInfrared), IlluminanceMeasurementServer), {
       id: 'OnOffPlugin3',
       identify: {
         identifyTime: 0,

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -771,7 +771,7 @@ describe('MatterbridgeEndpointMatterJs', () => {
       expect(attributeId).toBeDefined();
       count++;
     });
-    expect(count).toBe(101);
+    expect(count).toBe(73);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { jest } from '@jest/globals';
-import { DeviceTypeId, VendorId, ServerNode, Endpoint, EndpointServer, StorageContext, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel } from '@matter/main';
+import { DeviceTypeId, VendorId, ServerNode, Endpoint, StorageContext, LogFormat as MatterLogFormat, LogLevel as MatterLogLevel } from '@matter/main';
 import {
   ColorControl,
   Descriptor,
@@ -350,11 +350,11 @@ describe('MatterbridgeEndpointMatterJs', () => {
 
   test('add onOffLight device to serverNode', async () => {
     expect(await server.add(light)).toBeDefined();
-    expect(EndpointServer.forEndpoint(light).hasClusterServer(DescriptorCluster)).toBe(true);
-    expect(EndpointServer.forEndpoint(light).hasClusterServer(IdentifyCluster)).toBe(true);
-    expect(EndpointServer.forEndpoint(light).hasClusterServer(GroupsCluster)).toBe(true);
-    expect(EndpointServer.forEndpoint(light).hasClusterServer(ScenesManagementCluster)).toBe(false);
-    expect(EndpointServer.forEndpoint(light).hasClusterServer(OnOffCluster)).toBe(true);
+    expect(light.hasClusterServer(DescriptorCluster)).toBe(true);
+    expect(light.hasClusterServer(IdentifyCluster)).toBe(true);
+    expect(light.hasClusterServer(GroupsCluster)).toBe(true);
+    expect(light.hasClusterServer(ScenesManagementCluster)).toBe(false);
+    expect(light.hasClusterServer(OnOffCluster)).toBe(true);
   });
 
   test('add rollerDevice device to serverNode', async () => {
@@ -433,7 +433,6 @@ describe('MatterbridgeEndpointMatterJs', () => {
       ],
     });
     expect(await server.add(endpoint)).toBeDefined();
-    logEndpoint(EndpointServer.forEndpoint(endpoint));
   });
 
   test('add deviceType to onOffPlugin with tagList', async () => {
@@ -470,7 +469,6 @@ describe('MatterbridgeEndpointMatterJs', () => {
       }),
     ).not.toThrow();
     await expect(server.add(endpoint)).resolves.toBeDefined();
-    logEndpoint(EndpointServer.forEndpoint(endpoint));
   });
 
   test('add deviceType to onOffPlugin in the costructor', async () => {
@@ -499,7 +497,6 @@ describe('MatterbridgeEndpointMatterJs', () => {
     });
     expect(endpoint).toBeDefined();
     await expect(server.add(endpoint)).resolves.toBeDefined();
-    logEndpoint(EndpointServer.forEndpoint(endpoint));
     const deviceTypeList = endpoint.state.descriptor.deviceTypeList;
     expect(deviceTypeList).toHaveLength(3);
     expect(deviceTypeList[0].deviceType).toBe(onOffOutlet.code);
@@ -523,10 +520,6 @@ describe('MatterbridgeEndpointMatterJs', () => {
     });
     expect(endpoint).toBeDefined();
     await expect(server.add(endpoint)).resolves.toBeDefined();
-    // consoleLogSpy?.mockRestore();
-    // consoleInfoSpy?.mockRestore();
-    // logEndpoint(EndpointServer.forEndpoint(endpoint));
-    // console.log('ContactSensor1 descriptor state:', endpoint.state.descriptor);
   });
 
   test('create an Rvc device', async () => {
@@ -570,16 +563,6 @@ describe('MatterbridgeEndpointMatterJs', () => {
 
   test('log onOffLight', async () => {
     expect(light).toBeDefined();
-    /*
-      logEndpoint(EndpointServer.forEndpoint(light));
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(DescriptorCluster)).toBe(true);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(BasicInformationCluster)).toBe(false);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(BridgedDeviceBasicInformationCluster)).toBe(false);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(IdentifyCluster)).toBe(true);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(OnOffCluster)).toBe(true);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(GroupsCluster)).toBe(true);
-      expect(EndpointServer.forEndpoint(light).hasClusterServer(ScenesManagementCluster)).toBe(false);
-      */
   });
 
   test('get MatterbridgeServerDevice', async () => {

--- a/src/matterbridgeEndpoint.test.ts
+++ b/src/matterbridgeEndpoint.test.ts
@@ -742,7 +742,7 @@ describe('MatterbridgeEndpoint', () => {
         expect(attributeId).toBeDefined();
         count++;
       });
-      expect(count).toBe(85);
+      expect(count).toBe(59);
     });
 
     test('forEachAttribute DishWasher', async () => {
@@ -762,7 +762,7 @@ describe('MatterbridgeEndpoint', () => {
         expect(attributeId).toBeDefined();
         count++;
       });
-      expect(count).toBe(23);
+      expect(count).toBe(20);
     });
 
     test('forEachAttribute LaundryWasher', async () => {
@@ -785,7 +785,7 @@ describe('MatterbridgeEndpoint', () => {
         expect(attributeId).toBeDefined();
         count++;
       });
-      expect(count).toBe(34);
+      expect(count).toBe(26);
     });
 
     test('forEachAttribute ExtractorHood', async () => {
@@ -808,7 +808,7 @@ describe('MatterbridgeEndpoint', () => {
         expect(attributeId).toBeDefined();
         count++;
       });
-      expect(count).toBe(77);
+      expect(count).toBe(47);
     });
 
     test('forEachAttribute AirQuality', async () => {
@@ -828,7 +828,7 @@ describe('MatterbridgeEndpoint', () => {
         expect(attributeId).toBeDefined();
         count++;
       });
-      expect(count).toBe(216);
+      expect(count).toBe(150);
 
       loggerLogSpy.mockClear();
       expect(await device.setAttribute(TemperatureMeasurementServer, 'measuredValue', 2500, device.log)).toBeTruthy();

--- a/src/matterbridgeEndpoint.test.ts
+++ b/src/matterbridgeEndpoint.test.ts
@@ -72,13 +72,16 @@ import {
 } from './matterbridgeDeviceTypes.js';
 import { checkNotLatinCharacters, generateUniqueId, getAttributeId, getClusterId } from './matterbridgeEndpointHelpers.js';
 
+const MATTER_PORT = 6003;
+const HOMEDIR = 'Endpoint';
+
 let loggerLogSpy: jest.SpiedFunction<typeof AnsiLogger.prototype.log>;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
 let consoleDebugSpy: jest.SpiedFunction<typeof console.log>;
 let consoleInfoSpy: jest.SpiedFunction<typeof console.log>;
 let consoleWarnSpy: jest.SpiedFunction<typeof console.log>;
 let consoleErrorSpy: jest.SpiedFunction<typeof console.log>;
-const debug = false; // Set to true to enable debug logs
+const debug = true; // Set to true to enable debug logs
 
 if (!debug) {
   loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
@@ -97,9 +100,9 @@ if (!debug) {
 }
 
 // Cleanup the matter environment
-rmSync(path.join('test', 'Endpoint'), { recursive: true, force: true });
+rmSync(path.join('test', HOMEDIR), { recursive: true, force: true });
 
-describe('MatterbridgeEndpoint', () => {
+describe('Matterbridge ' + HOMEDIR, () => {
   let matterbridge: Matterbridge;
   let device: MatterbridgeEndpoint;
 
@@ -128,7 +131,7 @@ describe('MatterbridgeEndpoint', () => {
 
   beforeAll(async () => {
     // Create a MatterbridgeEdge instance
-    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-homedir', path.join('test', 'Endpoint'), '-bridge', '-logger', 'info', '-matterlogger', 'info'];
+    process.argv = ['node', 'matterbridge.js', '-mdnsInterface', 'Wi-Fi', '-frontend', '0', '-port', MATTER_PORT.toString(), '-homedir', path.join('test', HOMEDIR), '-bridge', '-logger', 'info', '-matterlogger', 'info'];
     matterbridge = await Matterbridge.loadInstance(true);
     await waitForOnline();
   }, 30000);
@@ -147,7 +150,7 @@ describe('MatterbridgeEndpoint', () => {
     jest.restoreAllMocks();
   }, 30000);
 
-  describe('MatterbridgeEndpoint', () => {
+  describe('Matterbridge ' + HOMEDIR, () => {
     async function add(device: MatterbridgeEndpoint): Promise<void> {
       expect(device).toBeDefined();
       device.addRequiredClusterServers();
@@ -333,7 +336,7 @@ describe('MatterbridgeEndpoint', () => {
         .createDefaultIdentifyClusterServer()
         .createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light')
         .createDefaultGroupsClusterServer()
-        .createDefaultScenesClusterServer()
+        // .createDefaultScenesClusterServer()
         .createDefaultOnOffClusterServer()
         .createDefaultPowerSourceWiredClusterServer();
       const serializedDevice = MatterbridgeEndpoint.serialize(device);
@@ -589,8 +592,10 @@ describe('MatterbridgeEndpoint', () => {
       ]);
     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
+    /*
     test('subscribeAttribute without await', async () => {
-      const device = new MatterbridgeEndpoint(rainSensor, { uniqueStorageKey: 'RainSensorI' });
+      const device = new MatterbridgeEndpoint(rainSensor, { uniqueStorageKey: 'RainSensorI' }, true);
       expect(device).toBeDefined();
       device.createDefaultIdentifyClusterServer();
       device.createDefaultBooleanStateClusterServer(true);
@@ -605,21 +610,24 @@ describe('MatterbridgeEndpoint', () => {
       expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`is in the ${BLUE}inactive${db} state`));
 
       await add(device);
+      console.log('subscribeAttribute without await: add(device)', state);
 
       await device.setAttribute(BooleanStateCluster, 'stateValue', false, device.log);
       expect(state).toBe(false);
       expect(device.getAttribute(BooleanStateServer, 'stateValue', device.log)).toBe(false);
       await device.setAttribute(BooleanStateCluster, 'stateValue', true, device.log);
       expect(state).toBe(true);
+      console.log('subscribeAttribute without await: state', state);
       expect(device.getAttribute(BooleanStateBehavior, 'stateValue', device.log)).toBe(true);
       expect(device.getAttribute(BooleanStateServer, 'stateValue', device.log)).toBe(true);
       expect(device.getAttribute(BooleanState.Cluster, 'stateValue', device.log)).toBe(true);
       expect(device.getAttribute(BooleanState.Cluster.id, 'stateValue', device.log)).toBe(true);
       expect(device.getAttribute('BooleanState', 'stateValue', device.log)).toBe(true);
+      console.log('subscribeAttribute without await: state', state);
     });
 
     test('subscribeAttribute await', async () => {
-      const device = new MatterbridgeEndpoint(rainSensor, { uniqueStorageKey: 'RainSensorII' });
+      const device = new MatterbridgeEndpoint(rainSensor, { uniqueStorageKey: 'RainSensorII' }, true);
       expect(device).toBeDefined();
       device.createDefaultIdentifyClusterServer();
       device.createDefaultBooleanStateClusterServer(true);
@@ -658,6 +666,7 @@ describe('MatterbridgeEndpoint', () => {
       expect(device.getAttribute(BooleanState.Cluster.id, 'stateValue', device.log)).toBe(true);
       expect(device.getAttribute('BooleanState', 'stateValue', device.log)).toBe(true);
     });
+    */
 
     test('addCommandHandler', async () => {
       const device = new MatterbridgeEndpoint(onOffLight, { uniqueStorageKey: 'OnOffLight7' });

--- a/src/matterbridgeEndpoint.test.ts
+++ b/src/matterbridgeEndpoint.test.ts
@@ -516,7 +516,7 @@ describe('Matterbridge ' + HOMEDIR, () => {
         },
         options: { executeIfOff: false },
         numberOfPrimaries: null,
-        colorTemperatureMireds: 500,
+        colorTemperatureMireds: 250,
         colorTempPhysicalMinMireds: 147,
         colorTempPhysicalMaxMireds: 500,
         coupleColorTempToLevelMinMireds: 147,

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -618,15 +618,19 @@ export class MatterbridgeEndpoint extends Endpoint {
     if (!this.lifecycle.isReady || this.construction.status !== Lifecycle.Status.Active) return;
 
     for (const [clusterName, clusterAttributes] of Object.entries(this.state as unknown as Record<string, Record<string, boolean | number | bigint | string | object | undefined | null>>)) {
+      // Skip if the key / cluster name is a number, cause they are double indexed.
+      if (!isNaN(Number(clusterName))) continue;
       for (const [attributeName, attributeValue] of Object.entries(clusterAttributes)) {
+        // Skip if the behavior has no associated cluster (i.e. matterbridge server)
         const clusterId = getClusterId(this, clusterName);
         if (clusterId === undefined) {
-          // this.log.error(`forEachAttribute error: cluster ${clusterName} not found`);
+          // this.log.debug(`***forEachAttribute: cluster ${clusterName} not found`);
           continue;
         }
+        // Skip if the attribute is not present in the ClusterBehavior.Type
         const attributeId = getAttributeId(this, clusterName, attributeName);
         if (attributeId === undefined) {
-          // this.log.error(`forEachAttribute error: attribute ${clusterName}.${attributeName} not found`);
+          // this.log.debug(`***forEachAttribute: attribute ${clusterName}.${attributeName} not found`);
           continue;
         }
         callback(clusterName, clusterId, attributeName, attributeId, attributeValue);

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2126,7 +2126,7 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a default OccupancySensing cluster server.
+   * Creates a default OccupancySensing cluster server with feature PassiveInfrared.
    *
    * @param {boolean} occupied - A boolean indicating whether the occupancy is occupied or not. Default is false.
    * @param {number} holdTime - The hold time in seconds. Default is 30.

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1529,10 +1529,15 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a default fan control cluster server.
+   * Creates a default fan control cluster server with features MultiSpeed, Auto, and Step.
    *
-   * @param fanMode The fan mode to set. Defaults to `FanControl.FanMode.Off`.
+   * @param {FanControl.FanMode} [fanMode=FanControl.FanMode.Off] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * fanmode is writable and persists across reboots.
+   * percentSetting is writable.
+   * speedSetting is writable.
    */
   createDefaultFanControlClusterServer(fanMode = FanControl.FanMode.Off) {
     this.behaviors.require(MatterbridgeFanControlServer.with(FanControl.Feature.MultiSpeed, FanControl.Feature.Auto, FanControl.Feature.Step), {
@@ -1548,10 +1553,14 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a base fan control cluster server.
+   * Creates a base fan control cluster server without features.
    *
-   * @param fanMode The fan mode to set. Defaults to `FanControl.FanMode.Off`.
+   * @param {FanControl.FanMode} [fanMode=FanControl.FanMode.Off] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * fanmode is writable and persists across reboots.
+   * percentSetting is writable.
    */
   createBaseFanControlClusterServer(fanMode = FanControl.FanMode.Off) {
     this.behaviors.require(FanControlServer, {

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -76,7 +76,7 @@ import {
 } from './matterbridgeEndpointHelpers.js';
 
 // @matter
-import { AtLeastOne, Behavior, ClusterId, Endpoint, EndpointNumber, EndpointType, HandlerFunction, Lifecycle, MutableEndpoint, NamedHandler, SupportedBehaviors, UINT16_MAX, UINT32_MAX, VendorId } from '@matter/main';
+import { ActionContext, AtLeastOne, Behavior, ClusterId, Endpoint, EndpointNumber, EndpointType, HandlerFunction, Lifecycle, MutableEndpoint, NamedHandler, SupportedBehaviors, UINT16_MAX, UINT32_MAX, VendorId } from '@matter/main';
 import { DeviceClassification } from '@matter/main/model';
 import { ClusterType, getClusterNameById, MeasurementType, Semtag } from '@matter/main/types';
 
@@ -468,7 +468,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @returns {Promise<boolean>} - A boolean indicating whether the subscription was successful.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async subscribeAttribute(cluster: Behavior.Type | ClusterType | ClusterId | string, attribute: string, listener: (newValue: any, oldValue: any, context?: any) => void, log?: AnsiLogger): Promise<boolean> {
+  async subscribeAttribute(cluster: Behavior.Type | ClusterType | ClusterId | string, attribute: string, listener: (newValue: any, oldValue: any, context: ActionContext) => void, log?: AnsiLogger): Promise<boolean> {
     return await subscribeAttribute(this, cluster, attribute, listener, log);
   }
 
@@ -555,6 +555,8 @@ export class MatterbridgeEndpoint extends Endpoint {
    *
    * @param {keyof MatterbridgeEndpointCommands} command - The command to execute.
    * @param {Record<string, boolean | number | bigint | string | object | null>} [request] - The optional request to pass to the handler function.
+   *
+   * @deprecated Used ONLY in Jest tests.
    */
   async executeCommandHandler(command: keyof MatterbridgeEndpointCommands, request?: Record<string, boolean | number | bigint | string | object | null>) {
     await this.commandHandler.executeHandler(command, { request });
@@ -566,6 +568,8 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {Behavior.Type | ClusterType | ClusterId | string} cluster - The cluster to invoke the command on.
    * @param {string} command - The command to invoke.
    * @param {Record<string, boolean | number | bigint | string | object | null>} [params] - The optional parameters to pass to the command.
+   *
+   * @deprecated Used ONLY in Jest tests.
    */
   async invokeBehaviorCommand(cluster: Behavior.Type | ClusterType | ClusterId | string, command: keyof MatterbridgeEndpointCommands, params?: Record<string, boolean | number | bigint | string | object | null>) {
     await invokeBehaviorCommand(this, cluster, command, params);

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -34,7 +34,8 @@ import {
   MatterbridgeOnOffServer,
   MatterbridgeLevelControlServer,
   MatterbridgeColorControlServer,
-  MatterbridgeWindowCoveringServer,
+  MatterbridgeLiftWindowCoveringServer,
+  MatterbridgeTiltWindowCoveringServer,
   MatterbridgeThermostatServer,
   MatterbridgeFanControlServer,
   MatterbridgeDoorLockServer,
@@ -175,6 +176,7 @@ export interface MatterbridgeEndpointCommands {
   downOrClose: HandlerFunction;
   stopMotion: HandlerFunction;
   goToLiftPercentage: HandlerFunction;
+  goToTiltPercentage: HandlerFunction;
 
   // Door Lock
   lockDoor: HandlerFunction;
@@ -1330,9 +1332,13 @@ export class MatterbridgeEndpoint extends Endpoint {
    *
    * @param positionPercent100ths - The position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks mode attributes is writable and persists across restarts.
+   * currentPositionLiftPercent100ths persists across restarts.
+   * configStatus attributes persists across restarts.
    */
   createDefaultWindowCoveringClusterServer(positionPercent100ths?: number) {
-    this.behaviors.require(MatterbridgeWindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift), {
+    this.behaviors.require(MatterbridgeLiftWindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift), {
       type: WindowCovering.WindowCoveringType.Rollershade,
       configStatus: {
         operational: true,
@@ -1357,9 +1363,13 @@ export class MatterbridgeEndpoint extends Endpoint {
    *
    * @param positionPercent100ths - The position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks mode attributes is writable and persists across restarts.
+   * currentPositionTiltPercent100ths persists across restarts.
+   * configStatus attributes persists across restarts.
    */
   createDefaultTiltWindowCoveringClusterServer(positionPercent100ths?: number) {
-    this.behaviors.require(MatterbridgeWindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt), {
+    this.behaviors.require(MatterbridgeTiltWindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt), {
       type: WindowCovering.WindowCoveringType.Shutter,
       configStatus: {
         operational: true,

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -465,9 +465,14 @@ export class MatterbridgeEndpoint extends Endpoint {
    *
    * @param {Behavior.Type | ClusterType | ClusterId | string} cluster - The cluster to subscribe the attribute to.
    * @param {string} attribute - The name of the attribute to subscribe to.
-   * @param {(newValue: any, oldValue: any, context?: any) => void} listener - A callback function that will be called when the attribute value changes.
+   * @param {(newValue: any, oldValue: any, context: ActionContext) => void} listener - A callback function that will be called when the attribute value changes. When context.offline === true then the change is locally generated and not from the controller.
    * @param {AnsiLogger} [log] - Optional logger for logging errors and information.
    * @returns {Promise<boolean>} - A boolean indicating whether the subscription was successful.
+   *
+   * @remarks The listener function (cannot be async) will receive three parameters:
+   * - `newValue`: The new value of the attribute.
+   * - `oldValue`: The old value of the attribute.
+   * - `context`: The action context, which includes information about the action that triggered the change. When context.offline === true then the change is locally generated and not from the controller.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async subscribeAttribute(cluster: Behavior.Type | ClusterType | ClusterId | string, attribute: string, listener: (newValue: any, oldValue: any, context: ActionContext) => void, log?: AnsiLogger): Promise<boolean> {

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1170,6 +1170,13 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param colorTempPhysicalMinMireds - The physical minimum color temperature in mireds (default range 147).
    * @param colorTempPhysicalMaxMireds - The physical maximum color temperature in mireds (default range 500).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks colorMode and enhancedColorMode persist across restarts.
+   * @remarks currentHue and currentSaturation persist across restarts.
+   * @remarks currentX and currentY persist across restarts.
+   * @remarks colorTemperatureMireds persists across restarts.
+   * @remarks startUpColorTemperatureMireds persists across restarts.
+   * @remarks coupleColorTempToLevelMinMireds persists across restarts.
    */
   createDefaultColorControlClusterServer(currentX = 0, currentY = 0, currentHue = 0, currentSaturation = 0, colorTemperatureMireds = 500, colorTempPhysicalMinMireds = 147, colorTempPhysicalMaxMireds = 500) {
     this.behaviors.require(MatterbridgeColorControlServer.with(ColorControl.Feature.Xy, ColorControl.Feature.HueSaturation, ColorControl.Feature.ColorTemperature), {
@@ -1188,8 +1195,8 @@ export class MatterbridgeEndpoint extends Endpoint {
       colorTempPhysicalMinMireds,
       colorTempPhysicalMaxMireds,
       coupleColorTempToLevelMinMireds: colorTempPhysicalMinMireds,
-      remainingTime: 0,
       startUpColorTemperatureMireds: null,
+      remainingTime: 0,
     });
     return this;
   }
@@ -1206,6 +1213,12 @@ export class MatterbridgeEndpoint extends Endpoint {
    *
    * @remarks
    * From zigbee to matter = Math.max(Math.min(Math.round(x * 65536), 65279), 0)
+   *
+   * @remarks colorMode and enhancedColorMode persist across restarts.
+   * @remarks currentX and currentY persist across restarts.
+   * @remarks colorTemperatureMireds persists across restarts.
+   * @remarks startUpColorTemperatureMireds persists across restarts.
+   * @remarks coupleColorTempToLevelMinMireds persists across restarts.
    */
   createXyColorControlClusterServer(currentX = 0, currentY = 0, colorTemperatureMireds = 500, colorTempPhysicalMinMireds = 147, colorTempPhysicalMaxMireds = 500) {
     this.behaviors.require(MatterbridgeColorControlServer.with(ColorControl.Feature.Xy, ColorControl.Feature.ColorTemperature), {
@@ -1237,6 +1250,12 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param colorTempPhysicalMinMireds - The physical minimum color temperature in mireds.
    * @param colorTempPhysicalMaxMireds - The physical maximum color temperature in mireds.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks colorMode and enhancedColorMode persist across restarts.
+   * @remarks currentHue and currentSaturation persist across restarts.
+   * @remarks colorTemperatureMireds persists across restarts.
+   * @remarks startUpColorTemperatureMireds persists across restarts.
+   * @remarks coupleColorTempToLevelMinMireds persists across restarts.
    */
   createHsColorControlClusterServer(currentHue = 0, currentSaturation = 0, colorTemperatureMireds = 500, colorTempPhysicalMinMireds = 147, colorTempPhysicalMaxMireds = 500) {
     this.behaviors.require(MatterbridgeColorControlServer.with(ColorControl.Feature.HueSaturation, ColorControl.Feature.ColorTemperature), {
@@ -1261,13 +1280,19 @@ export class MatterbridgeEndpoint extends Endpoint {
 
   /**
    * Creates a color temperature color control cluster server with feature ColorTemperature.
+   * This cluster server is used for devices that only support color temperature control.
    *
-   * @param colorTemperatureMireds - The color temperature in mireds.
-   * @param colorTempPhysicalMinMireds - The physical minimum color temperature in mireds.
-   * @param colorTempPhysicalMaxMireds - The physical maximum color temperature in mireds.
+   * @param colorTemperatureMireds - The color temperature in mireds. Defaults to 250.
+   * @param colorTempPhysicalMinMireds - The physical minimum color temperature in mireds. Defaults to 147.
+   * @param colorTempPhysicalMaxMireds - The physical maximum color temperature in mireds. Defaults to 500.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks colorMode and enhancedColorMode persist across restarts.
+   * @remarks colorTemperatureMireds persists across restarts.
+   * @remarks startUpColorTemperatureMireds persists across restarts.
+   * @remarks coupleColorTempToLevelMinMireds persists across restarts.
    */
-  createCtColorControlClusterServer(colorTemperatureMireds = 500, colorTempPhysicalMinMireds = 147, colorTempPhysicalMaxMireds = 500) {
+  createCtColorControlClusterServer(colorTemperatureMireds = 250, colorTempPhysicalMinMireds = 147, colorTempPhysicalMaxMireds = 500) {
     this.behaviors.require(MatterbridgeColorControlServer.with(ColorControl.Feature.ColorTemperature), {
       colorMode: ColorControl.ColorMode.ColorTemperatureMireds,
       enhancedColorMode: ColorControl.EnhancedColorMode.ColorTemperatureMireds,
@@ -1280,8 +1305,8 @@ export class MatterbridgeEndpoint extends Endpoint {
       colorTempPhysicalMinMireds,
       colorTempPhysicalMaxMireds,
       coupleColorTempToLevelMinMireds: colorTempPhysicalMinMireds,
-      remainingTime: 0,
       startUpColorTemperatureMireds: null,
+      remainingTime: 0,
     });
     return this;
   }
@@ -1290,6 +1315,8 @@ export class MatterbridgeEndpoint extends Endpoint {
    * Configures the color control mode for the device.
    *
    * @param {ColorControl.ColorMode} colorMode - The color mode to set.
+   *
+   * @remarks colorMode and enhancedColorMode persist across restarts.
    */
   async configureColorControlMode(colorMode: ColorControl.ColorMode) {
     if (isValidNumber(colorMode, ColorControl.ColorMode.CurrentHueAndCurrentSaturation, ColorControl.ColorMode.ColorTemperatureMireds)) {

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -35,7 +35,7 @@ import {
   MatterbridgeLevelControlServer,
   MatterbridgeColorControlServer,
   MatterbridgeLiftWindowCoveringServer,
-  MatterbridgeTiltWindowCoveringServer,
+  MatterbridgeLiftTiltWindowCoveringServer,
   MatterbridgeThermostatServer,
   MatterbridgeFanControlServer,
   MatterbridgeDoorLockServer,
@@ -1328,18 +1328,25 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a default window covering cluster server (Lift and PositionAwareLift).
+   * Creates a default window covering cluster server with feature Lift and PositionAwareLift.
    *
-   * @param positionPercent100ths - The position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
+   * @param {number} positionPercent100ths - The position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
+   * @param {WindowCovering.WindowCoveringType} type - The type of window covering (default: WindowCovering.WindowCoveringType.Rollershade). Must support feature Lift.
+   * @param {WindowCovering.EndProductType} endProductType - The end product type (default: WindowCovering.EndProductType.RollerShade). Must support feature Lift.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
    * @remarks mode attributes is writable and persists across restarts.
    * currentPositionLiftPercent100ths persists across restarts.
    * configStatus attributes persists across restarts.
    */
-  createDefaultWindowCoveringClusterServer(positionPercent100ths?: number) {
+  createDefaultWindowCoveringClusterServer(
+    positionPercent100ths?: number,
+    type: WindowCovering.WindowCoveringType = WindowCovering.WindowCoveringType.Rollershade,
+    endProductType: WindowCovering.EndProductType = WindowCovering.EndProductType.RollerShade,
+  ) {
     this.behaviors.require(MatterbridgeLiftWindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift), {
-      type: WindowCovering.WindowCoveringType.Rollershade,
+      type, // Must support feature Lift
+      numberOfActuationsLift: 0,
       configStatus: {
         operational: true,
         onlineReserved: false,
@@ -1350,7 +1357,7 @@ export class MatterbridgeEndpoint extends Endpoint {
         tiltEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
       },
       operationalStatus: { global: WindowCovering.MovementStatus.Stopped, lift: WindowCovering.MovementStatus.Stopped, tilt: WindowCovering.MovementStatus.Stopped },
-      endProductType: WindowCovering.EndProductType.RollerShade,
+      endProductType, // Must support feature Lift
       mode: { motorDirectionReversed: false, calibrationMode: false, maintenanceMode: false, ledFeedback: false },
       targetPositionLiftPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed
       currentPositionLiftPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed
@@ -1359,114 +1366,97 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a default tilt window covering cluster server (Tilt and PositionAwareTilt).
+   * Creates a default window covering cluster server with features Lift, PositionAwareLift, Tilt, PositionAwareTilt.
    *
-   * @param positionPercent100ths - The position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
+   * @param {number} positionLiftPercent100ths - The lift position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
+   * @param {number} positionTiltPercent100ths - The tilt position percentage in 100ths (0-10000). Defaults to 0. Matter uses 10000 = fully closed 0 = fully opened.
+   * @param {WindowCovering.WindowCoveringType} type - The type of window covering (default: WindowCovering.WindowCoveringType.TiltBlindLift). Must support features Lift and Tilt.
+   * @param {WindowCovering.EndProductType} endProductType - The end product type (default: WindowCovering.EndProductType.InteriorBlind). Must support features Lift and Tilt.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
    * @remarks mode attributes is writable and persists across restarts.
    * currentPositionTiltPercent100ths persists across restarts.
    * configStatus attributes persists across restarts.
    */
-  createDefaultTiltWindowCoveringClusterServer(positionPercent100ths?: number) {
-    this.behaviors.require(MatterbridgeTiltWindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt), {
-      type: WindowCovering.WindowCoveringType.Shutter,
+  createDefaultLiftTiltWindowCoveringClusterServer(
+    positionLiftPercent100ths?: number,
+    positionTiltPercent100ths?: number,
+    type: WindowCovering.WindowCoveringType = WindowCovering.WindowCoveringType.TiltBlindLift,
+    endProductType: WindowCovering.EndProductType = WindowCovering.EndProductType.InteriorBlind,
+  ) {
+    this.behaviors.require(MatterbridgeLiftTiltWindowCoveringServer.with(WindowCovering.Feature.Lift, WindowCovering.Feature.PositionAwareLift, WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt), {
+      type, // Must support features Lift and Tilt
+      numberOfActuationsLift: 0,
+      numberOfActuationsTilt: 0,
       configStatus: {
         operational: true,
         onlineReserved: false,
         liftMovementReversed: false,
-        liftPositionAware: false,
+        liftPositionAware: true,
         tiltPositionAware: true,
         liftEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
         tiltEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
       },
       operationalStatus: { global: WindowCovering.MovementStatus.Stopped, lift: WindowCovering.MovementStatus.Stopped, tilt: WindowCovering.MovementStatus.Stopped },
-      endProductType: WindowCovering.EndProductType.TiltOnlyPergola,
+      endProductType, // Must support features Lift and Tilt
       mode: { motorDirectionReversed: false, calibrationMode: false, maintenanceMode: false, ledFeedback: false },
-      targetPositionTiltPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed
-      currentPositionTiltPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed
+      targetPositionLiftPercent100ths: positionLiftPercent100ths ?? 0, // 0 Fully open 10000 fully closed
+      currentPositionLiftPercent100ths: positionLiftPercent100ths ?? 0, // 0 Fully open 10000 fully closed
+      targetPositionTiltPercent100ths: positionTiltPercent100ths ?? 0, // 0 Fully open 10000 fully closed
+      currentPositionTiltPercent100ths: positionTiltPercent100ths ?? 0, // 0 Fully open 10000 fully closed
     });
     return this;
   }
 
   /**
-   * Sets the window covering target position as the current position and stops the movement.
+   * Sets the window covering lift target position as the current position and stops the movement.
    *
-   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   async setWindowCoveringTargetAsCurrentAndStopped() {
-    if (this.hasAttributeServer(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')) {
-      const position = this.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', this.log);
-      if (isValidNumber(position, 0, 10000)) {
-        await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', position, this.log);
-        await this.setAttribute(
-          WindowCovering.Cluster.id,
-          'operationalStatus',
-          {
-            global: WindowCovering.MovementStatus.Stopped,
-            lift: WindowCovering.MovementStatus.Stopped,
-            tilt: WindowCovering.MovementStatus.Stopped,
-          },
-          this.log,
-        );
-      }
-      this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths and targetPositionLiftPercent100ths to ${position} and operationalStatus to Stopped.`);
-    } else {
+    const position = this.getAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', this.log);
+    if (isValidNumber(position, 0, 10000)) {
+      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', position, this.log);
+      await this.setAttribute(
+        WindowCovering.Cluster.id,
+        'operationalStatus',
+        {
+          global: WindowCovering.MovementStatus.Stopped,
+          lift: WindowCovering.MovementStatus.Stopped,
+          tilt: WindowCovering.MovementStatus.Stopped,
+        },
+        this.log,
+      );
+    }
+    this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths and targetPositionLiftPercent100ths to ${position} and operationalStatus to Stopped.`);
+    if (this.hasAttributeServer(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths')) {
       const position = this.getAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths', this.log);
       if (isValidNumber(position, 0, 10000)) {
         await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths', position, this.log);
-        await this.setAttribute(
-          WindowCovering.Cluster.id,
-          'operationalStatus',
-          {
-            global: WindowCovering.MovementStatus.Stopped,
-            lift: WindowCovering.MovementStatus.Stopped,
-            tilt: WindowCovering.MovementStatus.Stopped,
-          },
-          this.log,
-        );
       }
       this.log.debug(`Set WindowCovering currentPositionTiltPercent100ths and targetPositionTiltPercent100ths to ${position} and operationalStatus to Stopped.`);
     }
-    return this;
   }
 
   /**
-   * Sets the current and target status of a window covering.
+   * Sets the lift current and target position and the status of a window covering.
    * @param {number} current - The current position of the window covering.
    * @param {number} target - The target position of the window covering.
    * @param {WindowCovering.MovementStatus} status - The movement status of the window covering.
    */
   async setWindowCoveringCurrentTargetStatus(current: number, target: number, status: WindowCovering.MovementStatus) {
-    if (this.hasAttributeServer(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')) {
-      await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', current, this.log);
-      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', target, this.log);
-      await this.setAttribute(
-        WindowCovering.Cluster.id,
-        'operationalStatus',
-        {
-          global: status,
-          lift: status,
-          tilt: status,
-        },
-        this.log,
-      );
-      this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths: ${current}, targetPositionLiftPercent100ths: ${target} and operationalStatus: ${status}.`);
-    } else {
-      await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths', current, this.log);
-      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths', target, this.log);
-      await this.setAttribute(
-        WindowCovering.Cluster.id,
-        'operationalStatus',
-        {
-          global: status,
-          lift: status,
-          tilt: status,
-        },
-        this.log,
-      );
-      this.log.debug(`Set WindowCovering currentPositionTiltPercent100ths: ${current}, targetPositionTiltPercent100ths: ${target} and operationalStatus: ${status}.`);
-    }
+    await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', current, this.log);
+    await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', target, this.log);
+    await this.setAttribute(
+      WindowCovering.Cluster.id,
+      'operationalStatus',
+      {
+        global: status,
+        lift: status,
+        tilt: status,
+      },
+      this.log,
+    );
+    this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths: ${current}, targetPositionLiftPercent100ths: ${target} and operationalStatus: ${status}.`);
   }
 
   /**
@@ -1501,19 +1491,19 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Sets the target and current position of the window covering.
+   * Sets the lift target and current position of the window covering.
    *
-   * @param position - The position to set, specified as a number.
+   * @param {number} liftPosition - The position to set, specified as a number.
+   * @param {number} [tiltPosition] - The tilt position to set, specified as a number.
    */
-  async setWindowCoveringTargetAndCurrentPosition(position: number) {
-    if (this.hasAttributeServer(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths')) {
-      await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', position, this.log);
-      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', position, this.log);
-      this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths: ${position} and targetPositionLiftPercent100ths: ${position}.`);
-    } else {
-      await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths', position, this.log);
-      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths', position, this.log);
-      this.log.debug(`Set WindowCovering currentPositionTiltPercent100ths: ${position} and targetPositionTiltPercent100ths: ${position}.`);
+  async setWindowCoveringTargetAndCurrentPosition(liftPosition: number, tiltPosition?: number) {
+    await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionLiftPercent100ths', liftPosition, this.log);
+    await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionLiftPercent100ths', liftPosition, this.log);
+    this.log.debug(`Set WindowCovering currentPositionLiftPercent100ths: ${liftPosition} and targetPositionLiftPercent100ths: ${liftPosition}.`);
+    if (tiltPosition && this.hasAttributeServer(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths')) {
+      await this.setAttribute(WindowCovering.Cluster.id, 'currentPositionTiltPercent100ths', tiltPosition, this.log);
+      await this.setAttribute(WindowCovering.Cluster.id, 'targetPositionTiltPercent100ths', tiltPosition, this.log);
+      this.log.debug(`Set WindowCovering currentPositionTiltPercent100ths: ${tiltPosition} and targetPositionTiltPercent100ths: ${tiltPosition}.`);
     }
   }
 

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1328,12 +1328,12 @@ export class MatterbridgeEndpoint extends Endpoint {
       type: WindowCovering.WindowCoveringType.Rollershade,
       configStatus: {
         operational: true,
-        onlineReserved: true,
+        onlineReserved: false,
         liftMovementReversed: false,
         liftPositionAware: true,
         tiltPositionAware: false,
-        liftEncoderControlled: false,
-        tiltEncoderControlled: false,
+        liftEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
+        tiltEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
       },
       operationalStatus: { global: WindowCovering.MovementStatus.Stopped, lift: WindowCovering.MovementStatus.Stopped, tilt: WindowCovering.MovementStatus.Stopped },
       endProductType: WindowCovering.EndProductType.RollerShade,
@@ -1352,18 +1352,18 @@ export class MatterbridgeEndpoint extends Endpoint {
    */
   createDefaultTiltWindowCoveringClusterServer(positionPercent100ths?: number) {
     this.behaviors.require(MatterbridgeWindowCoveringServer.with(WindowCovering.Feature.Tilt, WindowCovering.Feature.PositionAwareTilt), {
-      type: WindowCovering.WindowCoveringType.Rollershade,
+      type: WindowCovering.WindowCoveringType.Shutter,
       configStatus: {
         operational: true,
-        onlineReserved: true,
+        onlineReserved: false,
         liftMovementReversed: false,
-        liftPositionAware: true,
-        tiltPositionAware: false,
-        liftEncoderControlled: false,
-        tiltEncoderControlled: false,
+        liftPositionAware: false,
+        tiltPositionAware: true,
+        liftEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
+        tiltEncoderControlled: false, // 0 = Timer Controlled 1 = Encoder Controlled
       },
       operationalStatus: { global: WindowCovering.MovementStatus.Stopped, lift: WindowCovering.MovementStatus.Stopped, tilt: WindowCovering.MovementStatus.Stopped },
-      endProductType: WindowCovering.EndProductType.RollerShade,
+      endProductType: WindowCovering.EndProductType.TiltOnlyPergola,
       mode: { motorDirectionReversed: false, calibrationMode: false, maintenanceMode: false, ledFeedback: false },
       targetPositionTiltPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed
       currentPositionTiltPercent100ths: positionPercent100ths ?? 0, // 0 Fully open 10000 fully closed

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -520,9 +520,14 @@ export async function updateAttribute(endpoint: MatterbridgeEndpoint, cluster: B
  * @param {MatterbridgeEndpoint} endpoint - The endpoint to subscribe the attribute to.
  * @param {Behavior.Type | ClusterType | ClusterId | string} cluster - The cluster to subscribe the attribute to.
  * @param {string} attribute - The name of the attribute to subscribe to.
- * @param {(newValue: any, oldValue: any, context?: any) => void} listener - A callback function that will be called when the attribute value changes.
+ * @param {(newValue: any, oldValue: any, context: ActionContext) => void} listener - A callback function that will be called when the attribute value changes. When context.offline === true then the change is locally generated and not from the controller.
  * @param {AnsiLogger} [log] - Optional logger for logging errors and information.
  * @returns {boolean} - A boolean indicating whether the subscription was successful.
+ *
+ * @remarks The listener function (cannot be async) will receive three parameters:
+ * - `newValue`: The new value of the attribute.
+ * - `oldValue`: The old value of the attribute.
+ * - `context`: The action context, which includes information about the action that triggered the change. When context.offline === true then the change is locally generated and not from the controller.
  */
 export async function subscribeAttribute(
   endpoint: MatterbridgeEndpoint,

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -222,7 +222,8 @@ export function getBehavior(endpoint: MatterbridgeEndpoint, cluster: Behavior.Ty
 }
 
 /**
- * Invokes a command on the specified behavior of the endpoint.
+ * Invokes a command on the specified behavior of the endpoint. Used ONLY in Jest tests.
+ *
  * @deprecated Used ONLY in Jest tests.
  */
 export async function invokeBehaviorCommand(

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -1,7 +1,7 @@
 // src\matterbridgeEndpointHelpers.ts
 
 // @matter
-import { Behavior, ClusterBehavior, ClusterId, Endpoint, Lifecycle } from '@matter/main';
+import { ActionContext, Behavior, ClusterBehavior, ClusterId, Endpoint, Lifecycle } from '@matter/main';
 import { ClusterType, getClusterNameById } from '@matter/main/types';
 
 // @matter clusters
@@ -221,6 +221,10 @@ export function getBehavior(endpoint: MatterbridgeEndpoint, cluster: Behavior.Ty
   return behavior;
 }
 
+/**
+ * Invokes a command on the specified behavior of the endpoint.
+ * @deprecated Used ONLY in Jest tests.
+ */
 export async function invokeBehaviorCommand(
   endpoint: MatterbridgeEndpoint,
   cluster: Behavior.Type | ClusterType | ClusterId | string,
@@ -524,7 +528,7 @@ export async function subscribeAttribute(
   cluster: Behavior.Type | ClusterType | ClusterId | string,
   attribute: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  listener: (newValue: any, oldValue: any, context?: any) => void,
+  listener: (newValue: any, oldValue: any, context: ActionContext) => void,
   log?: AnsiLogger,
 ): Promise<boolean> {
   const clusterName = getBehavior(endpoint, cluster)?.id;

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -382,7 +382,7 @@ export function getClusterId(endpoint: Endpoint, cluster: string) {
 
 export function getAttributeId(endpoint: Endpoint, cluster: string, attribute: string) {
   const clusterBehavior = endpoint.behaviors.supported[lowercaseFirstLetter(cluster)] as ClusterBehavior.Type | undefined;
-  return clusterBehavior?.cluster.attributes[attribute]?.id;
+  return clusterBehavior?.cluster.attributes[lowercaseFirstLetter(attribute)]?.id;
 }
 
 /**

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -1,7 +1,7 @@
 // src\matterbridgeEndpointHelpers.ts
 
 // @matter
-import { Behavior, ClusterId, Endpoint, Lifecycle } from '@matter/main';
+import { Behavior, ClusterBehavior, ClusterId, Endpoint, Lifecycle } from '@matter/main';
 import { ClusterType, getClusterNameById } from '@matter/main/types';
 
 // @matter clusters
@@ -381,36 +381,8 @@ export function getClusterId(endpoint: Endpoint, cluster: string) {
 }
 
 export function getAttributeId(endpoint: Endpoint, cluster: string, attribute: string) {
-  if (attribute === 'attributeList') return 0xfffb;
-  else if (attribute === 'featureMap') return 0xfffc;
-  else if (attribute === 'eventList') return 0xfffa;
-  else if (attribute === 'generatedCommandList') return 0xfff8;
-  else if (attribute === 'acceptedCommandList') return 0xfff9;
-  else if (attribute === 'clusterRevision') return 0xfffd;
-  else {
-    if (endpoint.behaviors.supported[lowercaseFirstLetter(cluster)]?.schema?.type === 'ConcentrationMeasurement') {
-      if (attribute === 'measuredValue') return 0x0;
-      else if (attribute === 'minMeasuredValue') return 0x1;
-      else if (attribute === 'maxMeasuredValue') return 0x2;
-      else if (attribute === 'peakMeasuredValue') return 0x3;
-      else if (attribute === 'peakMeasuredValueWindow') return 0x4;
-      else if (attribute === 'averageMeasuredValue') return 0x5;
-      else if (attribute === 'averageMeasuredValueWindow') return 0x6;
-      else if (attribute === 'uncertainty') return 0x7;
-      else if (attribute === 'measurementUnit') return 0x8;
-      else if (attribute === 'measurementMedium') return 0x9;
-      else if (attribute === 'levelValue') return 0xa;
-    }
-    if (endpoint.behaviors.supported[lowercaseFirstLetter(cluster)]?.schema?.type === 'OperationalState') {
-      if (attribute === 'phaseList') return 0x0;
-      else if (attribute === 'currentPhase') return 0x1;
-      else if (attribute === 'countdownTime') return 0x2;
-      else if (attribute === 'operationalStateList') return 0x3;
-      else if (attribute === 'operationalState') return 0x4;
-      else if (attribute === 'operationalError') return 0x5;
-    }
-    return endpoint.behaviors.supported[lowercaseFirstLetter(cluster)]?.schema?.children?.find((child) => child.name === capitalizeFirstLetter(attribute))?.id;
-  }
+  const clusterBehavior = endpoint.behaviors.supported[lowercaseFirstLetter(cluster)] as ClusterBehavior.Type | undefined;
+  return clusterBehavior?.cluster.attributes[attribute]?.id;
 }
 
 /**

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -91,7 +91,7 @@ import {
   MatterbridgeOnOffServer,
   MatterbridgeLevelControlServer,
   MatterbridgeColorControlServer,
-  MatterbridgeWindowCoveringServer,
+  MatterbridgeLiftWindowCoveringServer,
   MatterbridgeThermostatServer,
   MatterbridgeFanControlServer,
   MatterbridgeDoorLockServer,
@@ -166,7 +166,7 @@ export function getBehaviourTypeFromClusterServerId(clusterId: ClusterId) {
   if (clusterId === OnOff.Cluster.id) return MatterbridgeOnOffServer.with('Lighting');
   if (clusterId === LevelControl.Cluster.id) return MatterbridgeLevelControlServer.with('OnOff', 'Lighting');
   if (clusterId === ColorControl.Cluster.id) return MatterbridgeColorControlServer;
-  if (clusterId === WindowCovering.Cluster.id) return MatterbridgeWindowCoveringServer.with('Lift', 'PositionAwareLift');
+  if (clusterId === WindowCovering.Cluster.id) return MatterbridgeLiftWindowCoveringServer.with('Lift', 'PositionAwareLift');
   if (clusterId === Thermostat.Cluster.id) return MatterbridgeThermostatServer.with('AutoMode', 'Heating', 'Cooling');
   if (clusterId === FanControl.Cluster.id) return MatterbridgeFanControlServer;
   if (clusterId === DoorLock.Cluster.id) return MatterbridgeDoorLockServer;

--- a/src/matterbridgeTypes.ts
+++ b/src/matterbridgeTypes.ts
@@ -195,6 +195,15 @@ export interface ApiDevices {
   cluster: string;
 }
 
+export interface ApiClustersResponse {
+  plugin: string;
+  deviceName: string;
+  serialNumber: string;
+  endpoint: number;
+  deviceTypes: number[];
+  clusters: ApiClusters[];
+}
+
 export interface ApiClusters {
   endpoint: string;
   id: string;

--- a/src/roboticVacuumCleaner.test.ts
+++ b/src/roboticVacuumCleaner.test.ts
@@ -171,7 +171,7 @@ describe('Matterbridge Robotic Vacuum Cleaner', () => {
       expect(attributeId).toBeGreaterThanOrEqual(0);
       attributes.push({ clusterName, clusterId, attributeName, attributeId, attributeValue });
     });
-    expect(attributes.length).toBe(101);
+    expect(attributes.length).toBe(73);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {

--- a/src/roboticVacuumCleaner.test.ts
+++ b/src/roboticVacuumCleaner.test.ts
@@ -144,7 +144,6 @@ describe('Matterbridge Robotic Vacuum Cleaner', () => {
     expect(server.parts.has('RVCTestDevice-RVC123456')).toBeTruthy();
     expect(server.parts.has(device)).toBeTruthy();
     expect(device.lifecycle.isReady).toBeTruthy();
-    // logEndpoint(EndpointServer.forEndpoint(device));
   });
 
   test('start the server node', async () => {
@@ -152,7 +151,6 @@ describe('Matterbridge Robotic Vacuum Cleaner', () => {
     await server.start();
     expect(server.lifecycle.isReady).toBeTruthy();
     expect(server.lifecycle.isOnline).toBeTruthy();
-    // logEndpoint(EndpointServer.forEndpoint(server));
   });
 
   test('device forEachAttribute', async () => {

--- a/src/utils/createZip.test.ts
+++ b/src/utils/createZip.test.ts
@@ -1,4 +1,5 @@
 // src\utils\createZip.test.ts
+
 import { jest } from '@jest/globals';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';

--- a/src/utils/createZip.ts
+++ b/src/utils/createZip.ts
@@ -18,7 +18,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. *
+ * limitations under the License.
  */
 
 // Archiver module import types

--- a/src/waterHeater.test.ts
+++ b/src/waterHeater.test.ts
@@ -170,7 +170,7 @@ describe('Matterbridge Water Heater', () => {
       expect(attributeId).toBeGreaterThanOrEqual(0);
       attributes.push({ clusterName, clusterId, attributeName, attributeId, attributeValue });
     });
-    expect(attributes.length).toBe(145);
+    expect(attributes.length).toBe(84);
   });
 
   test('invoke MatterbridgeThermostatServer commands', async () => {

--- a/src/waterHeater.test.ts
+++ b/src/waterHeater.test.ts
@@ -143,7 +143,6 @@ describe('Matterbridge Water Heater', () => {
     expect(server.parts.has('WaterHeaterTestDevice-WH123456')).toBeTruthy();
     expect(server.parts.has(device)).toBeTruthy();
     expect(device.lifecycle.isReady).toBeTruthy();
-    // logEndpoint(EndpointServer.forEndpoint(device));
   });
 
   test('start the server node', async () => {
@@ -151,7 +150,6 @@ describe('Matterbridge Water Heater', () => {
     await server.start();
     expect(server.lifecycle.isReady).toBeTruthy();
     expect(server.lifecycle.isOnline).toBeTruthy();
-    // logEndpoint(EndpointServer.forEndpoint(server));
   });
 
   test('device forEachAttribute', async () => {


### PR DESCRIPTION
## [3.0.4] - 2025-05-26

### Added

- [jsdoc]: Improved jsdoc for cluster helpers.
- [cover]: Added createDefaultLiftTiltWindowCoveringClusterServer() that create a window covering cluser with both lift and tilt features (supported by Apple Home).

### Changed

- [legacy]: Removed legacy matter.js EndpointServer and logEndpoint that will be removed in matter.js 0.14.0. For developers: if you need to log the endpoint the call is Logger.get('LogEndpoint').info(endpoint).
- [package]: Updated dependencies.
- [package]: Updated multer package to 2.0.0.

### Fixed

- [virtualDevice]: Fixed possible vulnerability in the length of the nodeLabel.

<a href="https://www.buymeacoffee.com/luligugithub">
  <img src="bmc-button.svg" alt="Buy me a coffee" width="80">
</a>
