### PR TITLE
DeviceEnergyManagement cluster add parameters

### DIFF
--- a/src/evse.ts
+++ b/src/evse.ts
@@ -5,7 +5,7 @@
  * @author Luca Liguori
  * @contributor Ludovic BOUÉ
  * @date 2025-05-27
- * @version 1.0.0
+ * @version 1.0.1
  *
  * Copyright 2025, 2026, 2027 Luca Liguori.
  *

--- a/src/evse.ts
+++ b/src/evse.ts
@@ -41,16 +41,25 @@ export class Evse extends MatterbridgeEndpoint {
    *
    * @param {string} name - The name of the EVSE.
    * @param {string} serial - The serial number of the EVSE.
-   * @param {number} [currentMode] - The current mode of the EnergyEvseMode cluster. Defaults to mode 1 (EnergyEvseMode.ModeTag.Auto).
-   * @param {EnergyEvseMode.ModeOption[]} [supportedModes] - The supported modes for the EnergyEvseMode cluster. Defaults all cluster modes.
+   * @param {number} [currentMode] - The current mode of the EnergyEvseMode cluster. Defaults to mode 1 (EnergyEvseMode.ModeTag.Manual).
+   * @param {EnergyEvseMode.ModeOption[]} [supportedModes] - The supported modes for the EnergyEvseMode cluster. This is a fixed attribute that defaults to a predefined set of EnergyEvseMode cluster modes.
    * @param {EnergyEvse.State} [state] - The current state of the EVSE. Defaults to NotPluggedIn.
    * @param {EnergyEvse.SupplyState} [supplyState] - The supply state of the EVSE. Defaults to Disabled.
    * @param {EnergyEvse.FaultState} [faultState] - The fault state of the EVSE. Defaults to NoError.
    * @param {number} [absMinPower=0] - Indicate the minimum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
    * @param {number} [absMaxPower=0] - Indicate the maximum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
-
    */
-  constructor(name: string, serial: string, currentMode?: number, supportedModes?: EnergyEvseMode.ModeOption[], state?: EnergyEvse.State, supplyState?: EnergyEvse.SupplyState, faultState?: EnergyEvse.FaultState, absMinPower = 0, absMaxPower = 0) {
+  constructor(
+    name: string,
+    serial: string,
+    currentMode?: number,
+    supportedModes?: EnergyEvseMode.ModeOption[],
+    state?: EnergyEvse.State,
+    supplyState?: EnergyEvse.SupplyState,
+    faultState?: EnergyEvse.FaultState,
+    absMinPower?: number,
+    absMaxPower?: number,
+  ) {
     super([evse, powerSource, electricalSensor, deviceEnergyManagement], { uniqueStorageKey: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}` }, true);
     this.createDefaultIdentifyClusterServer()
       .createDefaultBasicInformationClusterServer(name, serial, 0xfff1, 'Matterbridge', 0x8000, 'Matterbridge EVSE')
@@ -95,10 +104,10 @@ export class Evse extends MatterbridgeEndpoint {
   createDefaultEnergyEvseModeClusterServer(currentMode?: number, supportedModes?: EnergyEvseMode.ModeOption[]): this {
     this.behaviors.require(MatterbridgeEnergyEvseModeServer, {
       supportedModes: supportedModes ?? [
-        { label: 'Manual', mode: 1, modeTags: [{ value: EnergyEvseMode.ModeTag.Manual }] },
-        { label: 'TimeOfUse', mode: 2, modeTags: [{ value: EnergyEvseMode.ModeTag.TimeOfUse }] },
-        { label: 'SolarCharging', mode: 3, modeTags: [{ value: EnergyEvseMode.ModeTag.SolarCharging }] },
-        { label: 'Home-to-vehicle and Vehicle-to-home', mode: 4, modeTags: [{ value: EnergyEvseMode.ModeTag.V2X }] },
+        { label: 'On demand', mode: 1, modeTags: [{ value: EnergyEvseMode.ModeTag.Manual }] },
+        { label: 'Scheduled', mode: 2, modeTags: [{ value: EnergyEvseMode.ModeTag.TimeOfUse }] },
+        { label: 'Solar charging', mode: 3, modeTags: [{ value: EnergyEvseMode.ModeTag.SolarCharging }] },
+        // { label: 'Home to vehicle and Vehicle to home', mode: 4, modeTags: [{ value: EnergyEvseMode.ModeTag.V2X }] },
       ], // FixedAttribute
       currentMode: currentMode ?? 1, // Persistent attribute
     });

--- a/src/evse.ts
+++ b/src/evse.ts
@@ -27,6 +27,7 @@ import { MaybePromise } from '@matter/main';
 import { EnergyEvseServer } from '@matter/main/behaviors/energy-evse';
 import { EnergyEvseModeServer } from '@matter/main/behaviors/energy-evse-mode';
 import { EnergyEvse, EnergyEvseMode } from '@matter/main/clusters';
+import { DeviceEnergyManagement } from '@matter/main/clusters/device-energy-management';
 import { ModeBase } from '@matter/main/clusters/mode-base';
 
 // Matterbridge
@@ -40,11 +41,16 @@ export class Evse extends MatterbridgeEndpoint {
    *
    * @param {string} name - The name of the EVSE.
    * @param {string} serial - The serial number of the EVSE.
+   * @param {number} [currentMode] - The current mode of the EnergyEvseMode cluster. Defaults to mode 1 (EnergyEvseMode.ModeTag.Auto).
+   * @param {EnergyEvseMode.ModeOption[]} [supportedModes] - The supported modes for the EnergyEvseMode cluster. Defaults all cluster modes.
    * @param {EnergyEvse.State} [state] - The current state of the EVSE. Defaults to NotPluggedIn.
    * @param {EnergyEvse.SupplyState} [supplyState] - The supply state of the EVSE. Defaults to Disabled.
    * @param {EnergyEvse.FaultState} [faultState] - The fault state of the EVSE. Defaults to NoError.
+   * @param {number} [absMinPower=0] - Indicate the minimum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
+   * @param {number} [absMaxPower=0] - Indicate the maximum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
+
    */
-  constructor(name: string, serial: string, currentMode?: number, supportedModes?: EnergyEvseMode.ModeOption[], state?: EnergyEvse.State, supplyState?: EnergyEvse.SupplyState, faultState?: EnergyEvse.FaultState) {
+  constructor(name: string, serial: string, currentMode?: number, supportedModes?: EnergyEvseMode.ModeOption[], state?: EnergyEvse.State, supplyState?: EnergyEvse.SupplyState, faultState?: EnergyEvse.FaultState, absMinPower = 0, absMaxPower = 0) {
     super([evse, powerSource, electricalSensor, deviceEnergyManagement], { uniqueStorageKey: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}` }, true);
     this.createDefaultIdentifyClusterServer()
       .createDefaultBasicInformationClusterServer(name, serial, 0xfff1, 'Matterbridge', 0x8000, 'Matterbridge EVSE')
@@ -52,7 +58,7 @@ export class Evse extends MatterbridgeEndpoint {
       .createDefaultPowerTopologyClusterServer()
       .createDefaultElectricalPowerMeasurementClusterServer()
       .createDefaultElectricalEnergyMeasurementClusterServer()
-      .createDefaultDeviceEnergyManagementCluster()
+      .createDefaultDeviceEnergyManagementCluster(DeviceEnergyManagement.EsaType.Evse, false, DeviceEnergyManagement.EsaState.Online, absMinPower, absMaxPower)
       .createDefaultEnergyEvseClusterServer(state, supplyState, faultState)
       .createDefaultEnergyEvseModeClusterServer(currentMode, supportedModes)
       .addRequiredClusterServers();

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2074,16 +2074,21 @@ export class MatterbridgeEndpoint extends Endpoint {
   /**
    * Creates a default Device Energy Management Cluster Server with feature PowerForecastReporting. Only needed for an evse device type.
    *
+   * @param {esaType} [esaType] - Indicate the type of Energy Smart Appliance (ESA). Defaults to Other.
+   * @param {boolean} [esaCanGenerate] - indicate whether the ESA is classed as a generator or load. Defaults to false.
+   * @param {esaState} [esaState] - Indicate the state of Energy Smart Appliance (ESA). Defaults to Offline.
+   * @param {number} [absMinPower=0] - Indicate the minimum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
+   * @param {number} [absMaxPower=0] - Indicate the maximum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
-  createDefaultDeviceEnergyManagementCluster() {
+  createDefaultDeviceEnergyManagementCluster(esaType = DeviceEnergyManagement.EsaType.Evse, esaCanGenerate = false, esaState = DeviceEnergyManagement.EsaState.Offline, absMinPower = 0, absMaxPower = 0) {
     this.behaviors.require(DeviceEnergyManagementServer.with(DeviceEnergyManagement.Feature.PowerForecastReporting), {
       forecast: null, // A null value indicates that there is no forecast currently available
-      esaType: DeviceEnergyManagement.EsaType.Other,
-      esaCanGenerate: false,
-      esaState: DeviceEnergyManagement.EsaState.Offline,
-      absMinPower: 0,
-      absMaxPower: 0,
+      esaType,
+      esaCanGenerate,
+      esaState,
+      absMinPower,
+      absMaxPower,
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2101,7 +2101,6 @@ export class MatterbridgeEndpoint extends Endpoint {
     return this;
   }
 
-
   /**
    * Creates a default EnergyManagementMode Cluster Server.
    *

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2072,26 +2072,35 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a default Device Energy Management Cluster Server with feature PowerForecastReporting. Only needed for an evse device type.
+   * Creates a default Device Energy Management Cluster Server with feature PowerForecastReporting and with the specified ESA type, ESA canGenerate, ESA state, and power limits.
    *
-   * @param {esaType} [esaType] - Indicate the type of Energy Smart Appliance (ESA). Defaults to Other.
-   * @param {boolean} [esaCanGenerate] - indicate whether the ESA is classed as a generator or load. Defaults to false.
-   * @param {esaState} [esaState] - Indicate the state of Energy Smart Appliance (ESA). Defaults to Offline.
-   * @param {number} [absMinPower=0] - Indicate the minimum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
-   * @param {number} [absMaxPower=0] - Indicate the maximum electrical power that the ESA can consume when switched on. Defaults to `0` if not provided.
+   * @param {DeviceEnergyManagement.EsaType} [esaType=DeviceEnergyManagement.EsaType.Other] - The ESA type. Defaults to `DeviceEnergyManagement.EsaType.Other`.
+   * @param {boolean} [esaCanGenerate=false] - Indicates if the ESA can generate energy. Defaults to `false`.
+   * @param {DeviceEnergyManagement.EsaState} [esaState=DeviceEnergyManagement.EsaState.Online] - The ESA state. Defaults to `DeviceEnergyManagement.EsaState.Online`.
+   * @param {number} [absMinPower=0] - The absolute minimum power in mW. Defaults to `0`.
+   * @param {number} [absMaxPower=0] - The absolute maximum power in mW. Defaults to `0`.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The forecast attribute is set to null, indicating that there is no forecast currently available.
+   * The ESA type and canGenerate attributes are fixed and cannot be changed after creation.
+   * The ESA state is set to Online by default.
+   * The absolute minimum and maximum power attributes are set to 0 by default.
+   * For example, a battery storage inverter that can charge its battery at a maximum power of 2000W and can
+   * discharge the battery at a maximum power of 3000W, would have a absMinPower: -3000W, absMaxPower: 2000W.
    */
-  createDefaultDeviceEnergyManagementCluster(esaType = DeviceEnergyManagement.EsaType.Evse, esaCanGenerate = false, esaState = DeviceEnergyManagement.EsaState.Offline, absMinPower = 0, absMaxPower = 0) {
+  createDefaultDeviceEnergyManagementCluster(esaType: DeviceEnergyManagement.EsaType = DeviceEnergyManagement.EsaType.Other, esaCanGenerate = false, esaState = DeviceEnergyManagement.EsaState.Online, absMinPower = 0, absMaxPower = 0) {
     this.behaviors.require(DeviceEnergyManagementServer.with(DeviceEnergyManagement.Feature.PowerForecastReporting), {
       forecast: null, // A null value indicates that there is no forecast currently available
-      esaType,
-      esaCanGenerate,
+      esaType, // Fixed attribute
+      esaCanGenerate, // Fixed attribute
       esaState,
       absMinPower,
       absMaxPower,
     });
     return this;
   }
+
 
   /**
    * Creates a default EnergyManagementMode Cluster Server.


### PR DESCRIPTION
Add parameters for `DeviceEnergyManagement `cluster
This will be usefull for other energy device types like `SolarPower`.