### PR TITLE
RVC SupportedMaps Attribute

### DIFF
--- a/src/devices/roboticVacuumCleaner.test.ts
+++ b/src/devices/roboticVacuumCleaner.test.ts
@@ -177,7 +177,7 @@ describe('Matterbridge Robotic Vacuum Cleaner', () => {
       expect(attributeId).toBeGreaterThanOrEqual(0);
       attributes.push({ clusterName, clusterId, attributeName, attributeId, attributeValue });
     });
-    expect(attributes.length).toBe(73);
+    expect(attributes.length).toBe(74);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -152,17 +152,19 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
         },
         {
           areaId: 2,
+          /* Have to set mapId=1 when matter.js bug is fixed */ 
           mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
-        /* Workaround because waiting for a fix https://github.com/project-chip/matter.js/issues/2238 */
         {
           areaId: 3,
+          /* Have to set mapId=2 when matter.js bug is fixed */ 
           mapId: 3,
           areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
+          /* Have to set mapId=2 when matter.js bug is fixed */ 
           mapId: 4,
           areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
@@ -178,10 +180,12 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
           mapId: 2,
           name: 'First floor',
         },
+        /* Workaround because waiting for a matter.js fix https://github.com/project-chip/matter.js/issues/2238 */
         {
           mapId: 3,
           name: 'Bedroom',
         },
+        /* Workaround because waiting for a matter.js fix */
         {
           mapId: 4,
           name: 'Bathroom',

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -57,7 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
-   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
    */
   constructor(
     name: string,
@@ -139,7 +139,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the ServiceArea cluster. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the ServiceArea cluster. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current areaId (not the index in the array!) of the ServiceArea cluster. Defaults to 1 (Living).
-   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number, supportedMaps?: ServiceArea.Map[]): this {
@@ -148,7 +148,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
         {
           areaId: 1,
           mapId: 1,
-          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: 0, areaType: AreaNamespaceTag.LivingRoom.tag, }, landmarkInfo: null },
+          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: 0, areaType: AreaNamespaceTag.LivingRoom.tag }, landmarkInfo: null },
         },
         {
           areaId: 2,
@@ -171,11 +171,11 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       supportedMaps: supportedMaps ?? [
         {
           mapId: 1,
-          name: "Ground floor",
+          name: 'Ground floor',
         },
         {
           mapId: 2,
-          name: "First floor",
+          name: 'First floor',
         },
       ],
       estimatedEndTime: null,

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -152,19 +152,19 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
         },
         {
           areaId: 2,
-          /* Have to set mapId=1 when matter.js bug is fixed */ 
+          /* Have to set mapId=1 when matter.js bug is fixed */
           mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          /* Have to set mapId=2 when matter.js bug is fixed */ 
+          /* Have to set mapId=2 when matter.js bug is fixed */
           mapId: 3,
           areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          /* Have to set mapId=2 when matter.js bug is fixed */ 
+          /* Have to set mapId=2 when matter.js bug is fixed */
           mapId: 4,
           areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -22,7 +22,7 @@
  */
 
 // Matter.js
-import { MaybePromise } from '@matter/main';
+import { AreaNamespaceTag, MaybePromise } from '@matter/main';
 import { RvcRunModeServer } from '@matter/main/behaviors/rvc-run-mode';
 import { RvcOperationalStateServer } from '@matter/main/behaviors/rvc-operational-state';
 import { RvcCleanModeServer } from '@matter/main/behaviors/rvc-clean-mode';
@@ -57,6 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
+   * @param {ServiceArea.Structs.MapStruct][]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
    */
   constructor(
     name: string,
@@ -73,6 +74,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
     supportedAreas?: ServiceArea.Area[],
     selectedAreas?: number[],
     currentArea?: number,
+    supportedMaps?: ServiceArea.Structs.MapStruct][],
   ) {
     super([roboticVacuumCleaner, powerSource], { uniqueStorageKey: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}`, mode }, true);
     this.createDefaultIdentifyClusterServer()
@@ -81,7 +83,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       .createDefaultRvcRunModeClusterServer(currentRunMode, supportedRunModes)
       .createDefaultRvcCleanModeClusterServer(currentCleanMode, supportedCleanModes)
       .createDefaultRvcOperationalStateClusterServer(phaseList, currentPhase, operationalStateList, operationalState)
-      .createDefaultServiceAreaClusterServer(supportedAreas, selectedAreas, currentArea);
+      .createDefaultServiceAreaClusterServer(supportedAreas, selectedAreas, currentArea, supportedMaps);
   }
 
   /**
@@ -137,34 +139,45 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the ServiceArea cluster. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the ServiceArea cluster. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current areaId (not the index in the array!) of the ServiceArea cluster. Defaults to 1 (Living).
+   * @param {ServiceArea.Structs.MapStruct][]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number): this {
-    this.behaviors.require(MatterbridgeServiceAreaServer, {
+    this.behaviors.require(MatterbridgeServiceAreaServer.with(ServiceArea.Feature.Maps), {
       supportedAreas: supportedAreas ?? [
         {
           areaId: 1,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: null, areaType: null }, landmarkInfo: null },
+          mapId: 1,
+          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: 0, areaType: AreaNamespaceTag.LivingRoom.tag, }, landmarkInfo: null },
         },
         {
           areaId: 2,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null },
+          mapId: 1,
+          areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null },
+          mapId: 2,
+          areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: null, areaType: null }, landmarkInfo: null },
+          mapId: 2,
+          areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
       ],
       selectedAreas: selectedAreas ?? [],
       currentArea: currentArea ?? 1,
+      supportedMaps: supportedMaps ?? [
+        {
+          mapId: 1,
+          name: "Ground floor",
+        },
+        {
+          mapId: 2,
+          name: "First floor",
+        },
+      ],
       estimatedEndTime: null,
     });
     return this;

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -57,7 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
-   * @param {ServiceArea.Structs.MapStruct][]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
    */
   constructor(
     name: string,
@@ -74,7 +74,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
     supportedAreas?: ServiceArea.Area[],
     selectedAreas?: number[],
     currentArea?: number,
-    supportedMaps?: ServiceArea.Structs.MapStruct][],
+    supportedMaps?: ServiceArea.Map[],
   ) {
     super([roboticVacuumCleaner, powerSource], { uniqueStorageKey: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}`, mode }, true);
     this.createDefaultIdentifyClusterServer()
@@ -139,10 +139,10 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the ServiceArea cluster. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the ServiceArea cluster. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current areaId (not the index in the array!) of the ServiceArea cluster. Defaults to 1 (Living).
-   * @param {ServiceArea.Structs.MapStruct][]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps. 
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
-  createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number): this {
+  createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number, supportedMaps?: ServiceArea.Map[]): this {
     this.behaviors.require(MatterbridgeServiceAreaServer.with(ServiceArea.Feature.Maps), {
       supportedAreas: supportedAreas ?? [
         {

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -152,17 +152,17 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
         },
         {
           areaId: 2,
-          mapId: 1,
+          mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          mapId: 2,
+          mapId: 3,
           areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          mapId: 2,
+          mapId: 4,
           areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
       ],
@@ -176,6 +176,14 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
         {
           mapId: 2,
           name: 'First floor',
+        },
+        {
+          mapId: 3,
+          name: 'Bedroom',
+        },
+        {
+          mapId: 4,
+          name: 'Bathroom',
         },
       ],
       estimatedEndTime: null,

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -155,6 +155,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
           mapId: 2,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
+        /* Workaround because waiting for a fix https://github.com/project-chip/matter.js/issues/2238 */
         {
           areaId: 3,
           mapId: 3,

--- a/src/matterbridge.test.ts
+++ b/src/matterbridge.test.ts
@@ -350,8 +350,9 @@ describe('Matterbridge', () => {
       expect((matterbridge as any).getVendorIdName(4718)).toContain('Xiaomi');
       expect((matterbridge as any).getVendorIdName(4742)).toContain('eWeLink');
       expect((matterbridge as any).getVendorIdName(5264)).toContain('Shelly');
-      expect((matterbridge as any).getVendorIdName(65521)).toContain('MatterServer');
-      expect((matterbridge as any).getVendorIdName(matterbridge.aggregatorVendorId)).toContain('MatterServer');
+      expect((matterbridge as any).getVendorIdName(0x1488)).toContain('ShortcutLabsFlic');
+      expect((matterbridge as any).getVendorIdName(65521)).toContain('MatterTest');
+      expect((matterbridge as any).getVendorIdName(matterbridge.aggregatorVendorId)).toContain('MatterTest');
       expect((matterbridge as any).getVendorIdName(1)).toContain('Unknown vendorId');
     });
 

--- a/src/matterbridge.ts
+++ b/src/matterbridge.ts
@@ -2804,6 +2804,9 @@ const commissioningController = new CommissioningController({
       case 5264:
         vendorName = '(Shelly)';
         break;
+      case 0x1488:
+        vendorName = '(ShortcutLabsFlic)';
+        break;
       case 65521:
         vendorName = '(MatterServer)';
         break;

--- a/src/matterbridge.ts
+++ b/src/matterbridge.ts
@@ -2807,8 +2807,8 @@ const commissioningController = new CommissioningController({
       case 0x1488:
         vendorName = '(ShortcutLabsFlic)';
         break;
-      case 65521:
-        vendorName = '(MatterServer)';
+      case 65521: // 0xFFF1
+        vendorName = '(MatterTest)';
         break;
     }
     return vendorName;

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -907,7 +907,7 @@ describe('Matterbridge ' + NAME, () => {
       expect(attributeId).toBeDefined();
       count++;
     });
-    expect(count).toBe(73);
+    expect(count).toBe(74);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2407,10 +2407,19 @@ export class MatterbridgeEndpoint extends Endpoint {
   /**
    * Creates a default PressureMeasurement cluster server.
    *
-   * @param {number | null} measuredValue - The measured value for the pressure.
-   * @param {number | null} minMeasuredValue - The minimum measured value for the pressure.
-   * @param {number | null} maxMeasuredValue - The maximum measured value for the pressure.
+   * @param {number | null} measuredValue - The measured value for the pressure in kPa x 10.
+   * @param {number | null} minMeasuredValue - The minimum measured value for the pressure in kPa x 10.
+   * @param {number | null} maxMeasuredValue - The maximum measured value for the pressure in kPa x 10.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * - MeasuredValue = 10 x Pressure in kPa
+   * - MeasuredValue = 1 x Pressure in hPa
+   * - MeasuredValue = 33.8639 x Pressure in inHg
+   *
+   * Conversion:
+   * - 1 kPa = 10 hPa
+   * - 1 inHg = 33.8639 hPa
    */
   createDefaultPressureMeasurementClusterServer(measuredValue: number | null = null, minMeasuredValue: number | null = null, maxMeasuredValue: number | null = null) {
     this.behaviors.require(PressureMeasurementServer, getDefaultPressureMeasurementClusterServer(measuredValue, minMeasuredValue, maxMeasuredValue));
@@ -2490,6 +2499,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @param {number} [uncertainty] - The uncertainty value (optional).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultTvocMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air, uncertainty?: number) {
     this.behaviors.require(TotalVolatileOrganicCompoundsConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2509,6 +2521,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.LevelValue} levelValue - The level value of the measurement (default to ConcentrationMeasurement.LevelValue.Unknown).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The measurement medium (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   * 
+   * @remarks
+   * The measurementMedium attribute is fixed and cannot be changed after creation.
    */
   createLevelTvocMeasurementClusterServer(levelValue = ConcentrationMeasurement.LevelValue.Unknown, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(TotalVolatileOrganicCompoundsConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.LevelIndication, ConcentrationMeasurement.Feature.MediumLevel, ConcentrationMeasurement.Feature.CriticalLevel), {
@@ -2525,6 +2540,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultCarbonMonoxideConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(CarbonMonoxideConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2545,6 +2563,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultCarbonDioxideConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(CarbonDioxideConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2565,6 +2586,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultFormaldehydeConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(FormaldehydeConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2585,6 +2609,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultPm1ConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(Pm1ConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2605,6 +2632,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultPm25ConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(Pm25ConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2625,6 +2655,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultPm10ConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(Pm10ConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2645,6 +2678,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ugm3).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultOzoneConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ugm3, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(OzoneConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2665,6 +2701,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ppm).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultRadonConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ppm, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(RadonConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {
@@ -2685,6 +2724,9 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {ConcentrationMeasurement.MeasurementUnit} measurementUnit - The unit of measurement (default to ConcentrationMeasurement.MeasurementUnit.Ugm3).
    * @param {ConcentrationMeasurement.MeasurementMedium} measurementMedium - The unit of measurement (default to ConcentrationMeasurement.MeasurementMedium.Air).
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * The measurementUnit and the measurementMedium attributes are fixed and cannot be changed after creation.
    */
   createDefaultNitrogenDioxideConcentrationMeasurementClusterServer(measuredValue: number | null = null, measurementUnit = ConcentrationMeasurement.MeasurementUnit.Ugm3, measurementMedium = ConcentrationMeasurement.MeasurementMedium.Air) {
     this.behaviors.require(NitrogenDioxideConcentrationMeasurementServer.with(ConcentrationMeasurement.Feature.NumericMeasurement), {

--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -830,9 +830,9 @@ export function getDefaultRelativeHumidityMeasurementClusterServer(measuredValue
 /**
  * Get the default PressureMeasurement cluster server options.
  *
- * @param {number | null} measuredValue - The measured value for the pressure.
- * @param {number | null} minMeasuredValue - The minimum measured value for the pressure.
- * @param {number | null} maxMeasuredValue - The maximum measured value for the pressure.
+ * @param {number | null} measuredValue - The measured value for the pressure in kPa x 10.
+ * @param {number | null} minMeasuredValue - The minimum measured value for the pressure in kPa x 10.
+ * @param {number | null} maxMeasuredValue - The maximum measured value for the pressure in kPa x 10.
  * @returns {Behavior.Options<MatterbridgePressureMeasurementServer>} - The default options for the PressureMeasurement cluster server.
  */
 export function getDefaultPressureMeasurementClusterServer(measuredValue: number | null = null, minMeasuredValue: number | null = null, maxMeasuredValue: number | null = null) {


### PR DESCRIPTION
RVC SupportedMaps Attribute

```
1.17.6.2. SupportedMaps Attribute
This attribute SHALL contain the list of supported maps.
A map is a full or a partial representation of a home, known to the device. For example:
• a single level home MAY be represented using a single map
• a two level home MAY be represented using two maps, one for each level
• a single level home MAY be represented using two maps, each including a different set of
rooms, such as "map of living room and kitchen" and "map of bedrooms and hallway"
• a single level home MAY be represented using one map for the indoor areas (living room, bed
rooms etc.) and one for the outdoor areas (garden, swimming pool etc.)
Each map includes one or more areas - see the SupportedAreas attribute. In the context of this clus
ter specification, a map is effectively a group label for a set of areas, rather than a graphical repre
sentation that the clients can display to the users. The clients that present the list of available areas
for user selection (see the SelectAreas command) MAY choose to filter the SupportedAreas list based
on the associated map. For example, the clients MAY allow the user to indicate that the device is to
operate on the first floor, and allow the user to choose only from the areas situated on that level.
If empty, that indicates that the device is currently unable to provide this information.
Each entry in this list SHALL have a unique value for the MapID field.
Each entry in this list SHALL have a unique value for the Name field
```

## Testing

### iOS
**Map 1**

![IMG_3432](https://github.com/user-attachments/assets/7d10acbc-a783-4ce6-98cc-22dc66a5f90e)

**Map 2**

![IMG_3433](https://github.com/user-attachments/assets/22c37270-831e-48fe-bf69-4a981332d550)
