### PR TITLE
RVC SupportedMaps Attribute

### DIFF
--- a/src/devices/roboticVacuumCleaner.test.ts
+++ b/src/devices/roboticVacuumCleaner.test.ts
@@ -177,7 +177,7 @@ describe('Matterbridge Robotic Vacuum Cleaner', () => {
       expect(attributeId).toBeGreaterThanOrEqual(0);
       attributes.push({ clusterName, clusterId, attributeName, attributeId, attributeValue });
     });
-    expect(attributes.length).toBe(73);
+    expect(attributes.length).toBe(74);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -57,7 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
-   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to null.
    */
   constructor(
     name: string,
@@ -147,50 +147,28 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       supportedAreas: supportedAreas ?? [
         {
           areaId: 1,
-          mapId: 1,
+          mapId: null,
           areaInfo: { locationInfo: { locationName: 'Living', floorNumber: 0, areaType: AreaNamespaceTag.LivingRoom.tag }, landmarkInfo: null },
         },
         {
           areaId: 2,
-          /* Have to set mapId=1 when matter.js bug is fixed */
-          mapId: 2,
+          mapId: null,
           areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          /* Have to set mapId=2 when matter.js bug is fixed */
-          mapId: 3,
+          mapId: null,
           areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          /* Have to set mapId=2 when matter.js bug is fixed */
-          mapId: 4,
+          mapId: null,
           areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
       ],
       selectedAreas: selectedAreas ?? [],
       currentArea: currentArea ?? 1,
-      supportedMaps: supportedMaps ?? [
-        {
-          mapId: 1,
-          name: 'Ground floor',
-        },
-        {
-          mapId: 2,
-          name: 'First floor',
-        },
-        /* Workaround because waiting for a matter.js fix https://github.com/project-chip/matter.js/issues/2238 */
-        {
-          mapId: 3,
-          name: 'Bedroom',
-        },
-        /* Workaround because waiting for a matter.js fix */
-        {
-          mapId: 4,
-          name: 'Bathroom',
-        },
-      ],
+      supportedMaps: null,
       estimatedEndTime: null,
     });
     return this;

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -57,7 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
-   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to null.
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to empty list.
    */
   constructor(
     name: string,

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -139,7 +139,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the ServiceArea cluster. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the ServiceArea cluster. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current areaId (not the index in the array!) of the ServiceArea cluster. Defaults to 1 (Living).
-   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults empty list.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number, supportedMaps?: ServiceArea.Map[]): this {
@@ -168,7 +168,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       ],
       selectedAreas: selectedAreas ?? [],
       currentArea: currentArea ?? 1,
-      supportedMaps: supportedMaps ??: ServiceArea.Map[], // Indicates that the device is currently unable to provide this information
+      supportedMaps: supportedMaps ?? [], // Indicates that the device is currently unable to provide this information
       estimatedEndTime: null,
     });
     return this;

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -168,7 +168,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       ],
       selectedAreas: selectedAreas ?? [],
       currentArea: currentArea ?? 1,
-      supportedMaps: null,
+      supportedMaps: supportedMaps ??: ServiceArea.Map[], // Indicates that the device is currently unable to provide this information
       estimatedEndTime: null,
     });
     return this;

--- a/src/devices/roboticVacuumCleaner.ts
+++ b/src/devices/roboticVacuumCleaner.ts
@@ -22,7 +22,7 @@
  */
 
 // Matter.js
-import { MaybePromise } from '@matter/main';
+import { AreaNamespaceTag, MaybePromise } from '@matter/main';
 import { RvcRunModeServer } from '@matter/main/behaviors/rvc-run-mode';
 import { RvcOperationalStateServer } from '@matter/main/behaviors/rvc-operational-state';
 import { RvcCleanModeServer } from '@matter/main/behaviors/rvc-clean-mode';
@@ -57,6 +57,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the robotic vacuum cleaner. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the robotic vacuum cleaner. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current area of the robotic vacuum cleaner. Defaults to 1 (Living).
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
    */
   constructor(
     name: string,
@@ -73,6 +74,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
     supportedAreas?: ServiceArea.Area[],
     selectedAreas?: number[],
     currentArea?: number,
+    supportedMaps?: ServiceArea.Map[],
   ) {
     super([roboticVacuumCleaner, powerSource], { uniqueStorageKey: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}`, mode }, true);
     this.createDefaultIdentifyClusterServer()
@@ -81,7 +83,7 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
       .createDefaultRvcRunModeClusterServer(currentRunMode, supportedRunModes)
       .createDefaultRvcCleanModeClusterServer(currentCleanMode, supportedCleanModes)
       .createDefaultRvcOperationalStateClusterServer(phaseList, currentPhase, operationalStateList, operationalState)
-      .createDefaultServiceAreaClusterServer(supportedAreas, selectedAreas, currentArea);
+      .createDefaultServiceAreaClusterServer(supportedAreas, selectedAreas, currentArea, supportedMaps);
   }
 
   /**
@@ -137,34 +139,58 @@ export class RoboticVacuumCleaner extends MatterbridgeEndpoint {
    * @param {ServiceArea.Area[]} [supportedAreas] - The supported areas for the ServiceArea cluster. Defaults to a predefined set of areas.
    * @param {number[]} [selectedAreas] - The selected areas for the ServiceArea cluster. Defaults to an empty array (all areas allowed).
    * @param {number} [currentArea] - The current areaId (not the index in the array!) of the ServiceArea cluster. Defaults to 1 (Living).
+   * @param {ServiceArea.Map[]} [supportedMaps] - The supported maps for the robotic vacuum cleaner. Defaults to a predefined set of maps.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
-  createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number): this {
-    this.behaviors.require(MatterbridgeServiceAreaServer, {
+  createDefaultServiceAreaClusterServer(supportedAreas?: ServiceArea.Area[], selectedAreas?: number[], currentArea?: number, supportedMaps?: ServiceArea.Map[]): this {
+    this.behaviors.require(MatterbridgeServiceAreaServer.with(ServiceArea.Feature.Maps), {
       supportedAreas: supportedAreas ?? [
         {
           areaId: 1,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: null, areaType: null }, landmarkInfo: null },
+          mapId: 1,
+          areaInfo: { locationInfo: { locationName: 'Living', floorNumber: 0, areaType: AreaNamespaceTag.LivingRoom.tag }, landmarkInfo: null },
         },
         {
           areaId: 2,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null },
+          /* Have to set mapId=1 when matter.js bug is fixed */
+          mapId: 2,
+          areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: 0, areaType: AreaNamespaceTag.Kitchen.tag }, landmarkInfo: null },
         },
         {
           areaId: 3,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null },
+          /* Have to set mapId=2 when matter.js bug is fixed */
+          mapId: 3,
+          areaInfo: { locationInfo: { locationName: 'Bedroom', floorNumber: 1, areaType: AreaNamespaceTag.Bedroom.tag }, landmarkInfo: null },
         },
         {
           areaId: 4,
-          mapId: null,
-          areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: null, areaType: null }, landmarkInfo: null },
+          /* Have to set mapId=2 when matter.js bug is fixed */
+          mapId: 4,
+          areaInfo: { locationInfo: { locationName: 'Bathroom', floorNumber: 1, areaType: AreaNamespaceTag.Bathroom.tag }, landmarkInfo: null },
         },
       ],
       selectedAreas: selectedAreas ?? [],
       currentArea: currentArea ?? 1,
+      supportedMaps: supportedMaps ?? [
+        {
+          mapId: 1,
+          name: 'Ground floor',
+        },
+        {
+          mapId: 2,
+          name: 'First floor',
+        },
+        /* Workaround because waiting for a matter.js fix https://github.com/project-chip/matter.js/issues/2238 */
+        {
+          mapId: 3,
+          name: 'Bedroom',
+        },
+        /* Workaround because waiting for a matter.js fix */
+        {
+          mapId: 4,
+          name: 'Bathroom',
+        },
+      ],
       estimatedEndTime: null,
     });
     return this;

--- a/src/matterbridgeEndpoint-matterjs.test.ts
+++ b/src/matterbridgeEndpoint-matterjs.test.ts
@@ -907,7 +907,7 @@ describe('Matterbridge ' + NAME, () => {
       expect(attributeId).toBeDefined();
       count++;
     });
-    expect(count).toBe(73);
+    expect(count).toBe(74);
   });
 
   test('invoke MatterbridgeRvcRunModeServer commands', async () => {


### PR DESCRIPTION
### Summary

Add RVC `SupportedMaps` Attribute from `ServiceArea` cluster. 
This allow to select room(s) in a map in Apple Home for example.

This is a follow-up to the previous request: #348.

### Specs

```
1.17.6.2. SupportedMaps Attribute
This attribute SHALL contain the list of supported maps.
A map is a full or a partial representation of a home, known to the device. For example:
• a single level home MAY be represented using a single map
• a two level home MAY be represented using two maps, one for each level
• a single level home MAY be represented using two maps, each including a different set of
rooms, such as "map of living room and kitchen" and "map of bedrooms and hallway"
• a single level home MAY be represented using one map for the indoor areas (living room, bed
rooms etc.) and one for the outdoor areas (garden, swimming pool etc.)
Each map includes one or more areas - see the SupportedAreas attribute. In the context of this clus
ter specification, a map is effectively a group label for a set of areas, rather than a graphical repre
sentation that the clients can display to the users. The clients that present the list of available areas
for user selection (see the SelectAreas command) MAY choose to filter the SupportedAreas list based
on the associated map. For example, the clients MAY allow the user to indicate that the device is to
operate on the first floor, and allow the user to choose only from the areas situated on that level.
If empty, that indicates that the device is currently unable to provide this information.
Each entry in this list SHALL have a unique value for the MapID field.
Each entry in this list SHALL have a unique value for the Name field
```

## Testing

### iOS
**Map 1**

![IMG_3432](https://github.com/user-attachments/assets/7d10acbc-a783-4ce6-98cc-22dc66a5f90e)

**Map 2**

![IMG_3433](https://github.com/user-attachments/assets/22c37270-831e-48fe-bf69-4a981332d550)
