### PR TITLE
Fan device with all features

### DIFF
--- a/src/matterbridgeEndpoint-default.test.ts
+++ b/src/matterbridgeEndpoint-default.test.ts
@@ -591,6 +591,24 @@ describe('Matterbridge ' + NAME, () => {
     (matterbridge as any).frontend.getClusterTextFromDevice(device);
   });
 
+  test('createCompleteFanControlClusterServer', async () => {
+    const device = new MatterbridgeEndpoint(fanDevice, { uniqueStorageKey: 'Fan4' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultGroupsClusterServer();
+    device.createCompleteFanControlClusterServer();
+    expect(device.hasAttributeServer(FanControl.Cluster, 'fanMode')).toBe(true);
+    expect(device.hasAttributeServer(FanControl.Cluster, 'percentSetting')).toBe(true);
+    expect(device.hasAttributeServer(FanControl.Cluster, 'speedSetting')).toBe(true);
+    expect(device.hasAttributeServer(FanControl.Cluster, 'rockSupport')).toBe(true);
+    expect(device.hasAttributeServer(FanControl.Cluster, 'windSupport')).toBe(true);
+    expect(device.hasAttributeServer(FanControl.Cluster, 'airflowDirection')).toBe(true);
+
+    await add(device);
+    expect(device.getAttribute(FanControl.Cluster.id, 'fanMode')).toBe(FanControl.FanMode.Off);
+    (matterbridge as any).frontend.getClusterTextFromDevice(device);
+  });
+
   test('createDefaultHepaFilterMonitoringClusterServer', async () => {
     const device = new MatterbridgeEndpoint(airPurifier, { uniqueStorageKey: 'AirPurifier' });
     expect(device).toBeDefined();

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1804,6 +1804,74 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
+   * Creates a fan control cluster server with features MultiSpeed, Auto, and Step.
+   *
+   * @param {FanControl.FanMode} [fanMode] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.
+   * @param {FanControl.FanModeSequence} [fanModeSequence] - The fan mode sequence to set. Defaults to `FanControl.FanModeSequence.OffLowMedHighAuto`.
+   * @param {number} [percentSetting] - The initial percent setting. Defaults to 0.
+   * @param {number} [percentCurrent] - The initial percent current. Defaults to 0.
+   * @param {number} [speedMax] - The maximum speed setting. Defaults to 10.
+   * @param {number} [speedSetting] - The initial speed setting. Defaults to 0.
+   * @param {number} [speedCurrent] - The initial speed current. Defaults to 0.
+   * @param {object} [rockSupport] - The rock support configuration.
+   * @param {object} [rockSetting] - The rock setting configuration.
+   * @param {object} [windSupport] - The wind support configuration.
+   * @param {object} [windSetting] - The wind setting configuration.
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * - fanmode is writable and persists across reboots.
+   * - fanModeSequence is fixed.
+   * - percentSetting is writable.
+   * - speedMax is fixed.
+   * - speedSetting is writable.
+   * - rockSupport is fixed.
+   * - rockSetting is writable.
+   * - windSupport is fixed.
+   * - windSetting is writable.
+   */
+
+  /*
+    0 RockLeftRight Indicate rock left to right
+    1 RockUpDown Indicate rock up and down
+    2 RockRound Indicate rock around
+  */
+  createCompleteFanControlClusterServer(
+    fanMode = FanControl.FanMode.Off,
+    fanModeSequence: FanControl.FanModeSequence = FanControl.FanModeSequence.OffLowMedHighAuto,
+    percentSetting = 0,
+    percentCurrent = 0,
+    speedMax = 10,
+    speedSetting = 0,
+    speedCurrent = 0,
+    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false, }, // Indicate rock left to right
+    rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false, }, // rockLeftRight default to off
+    windSupport = { sleepWind: false, naturalWind: true, }, // Indicate wind on
+    windSetting = { sleepWind: false, naturalWind: true, }, // naturalWind defaut to off
+  ) {
+    this.behaviors.require(MatterbridgeFanControlServer.with(
+      FanControl.Feature.MultiSpeed,
+      FanControl.Feature.Auto,
+      FanControl.Feature.Step,
+      FanControl.Feature.Rocking,
+      FanControl.Feature.Wind,
+    ), {
+      fanMode, // Writable and persistent attribute
+      fanModeSequence, // Fixed attribute
+      percentSetting, // Writable attribute
+      percentCurrent,
+      // MultiSpeed feature
+      speedMax, // Fixed attribute
+      speedSetting, // Writable attribute
+      speedCurrent,
+      // Rocking feature
+      rockSetting, // Writable attribute
+      windSetting, // Writable attribute
+    });
+    return this;
+  }
+
+  /**
    * Creates a base fan control cluster server without features.
    *
    * @param {FanControl.FanMode} [fanMode] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1830,12 +1830,6 @@ export class MatterbridgeEndpoint extends Endpoint {
    * - windSupport is fixed.
    * - windSetting is writable.
    */
-
-  /*
-    0 RockLeftRight Indicate rock left to right
-    1 RockUpDown Indicate rock up and down
-    2 RockRound Indicate rock around
-  */
   createCompleteFanControlClusterServer(
     fanMode = FanControl.FanMode.Off,
     fanModeSequence: FanControl.FanModeSequence = FanControl.FanModeSequence.OffLowMedHighAuto,
@@ -1847,7 +1841,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false, }, // Indicate rock left to right
     rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false, }, // rockLeftRight default to off
     windSupport = { sleepWind: false, naturalWind: true, }, // Indicate wind on
-    windSetting = { sleepWind: false, naturalWind: true, }, // naturalWind defaut to off
+    windSetting = { sleepWind: false, naturalWind: false, }, // naturalWind defaut to off
   ) {
     this.behaviors.require(MatterbridgeFanControlServer.with(
       FanControl.Feature.MultiSpeed,
@@ -1866,6 +1860,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       speedCurrent,
       // Rocking feature
       rockSetting, // Writable attribute
+      // Wind feature
       windSetting, // Writable attribute
     });
     return this;

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1859,8 +1859,10 @@ export class MatterbridgeEndpoint extends Endpoint {
       speedSetting, // Writable attribute
       speedCurrent,
       // Rocking feature
+      rockSupport, // Fixed attribute
       rockSetting, // Writable attribute
       // Wind feature
+      windSupport, // Fixed attribute
       windSetting, // Writable attribute
     });
     return this;

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1814,9 +1814,19 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {number} [speedSetting] - The initial speed setting. Defaults to 0.
    * @param {number} [speedCurrent] - The initial speed current. Defaults to 0.
    * @param {object} [rockSupport] - The rock support configuration.
+   * @param {boolean} rockSupport.rockLeftRight - Indicates support for rocking left to right. Defaults to true.
+   * @param {boolean} rockSupport.rockUpDown - Indicates support for rocking up and down. Defaults to true.
+   * @param {boolean} rockSupport.rockRound - Indicates support for round rocking. Defaults to true.
    * @param {object} [rockSetting] - The rock setting configuration.
+   * @param {boolean} rockSetting.rockLeftRight - Indicates the current setting for rocking left to right. Defaults to true.
+   * @param {boolean} rockSetting.rockUpDown - Indicates the current setting for rocking up and down. Defaults to true.
+   * @param {boolean} rockSetting.rockRound - Indicates the current setting for round rocking. Defaults to true.
    * @param {object} [windSupport] - The wind support configuration.
+   * @param {boolean} windSupport.sleepWind - Indicates support for sleep wind. Defaults to true.
+   * @param {boolean} windSupport.naturalWind - Indicates support for natural wind. Defaults to true.
    * @param {object} [windSetting] - The wind setting configuration.
+   * @param {boolean} windSetting.sleepWind - Indicates the current setting for sleep wind. Defaults to false.
+   * @param {boolean} windSetting.naturalWind - Indicates the current setting for natural wind. Defaults to true.
    * @param {FanControl.AirflowDirection} [airflowDirection] - The airflow direction. Defaults to `FanControl.AirflowDirection.Forward`.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
@@ -1833,20 +1843,21 @@ export class MatterbridgeEndpoint extends Endpoint {
    * - airflowDirection is writable.
    */
   createCompleteFanControlClusterServer(
-    fanMode = FanControl.FanMode.Off,
+    fanMode: FanControl.FanMode = FanControl.FanMode.Off,
     fanModeSequence: FanControl.FanModeSequence = FanControl.FanModeSequence.OffLowMedHighAuto,
-    percentSetting = 0,
-    percentCurrent = 0,
-    speedMax = 10,
-    speedSetting = 0,
-    speedCurrent = 0,
-    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false }, // Indicate rock left to right support
-    rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false }, // rockLeftRight default to off
-    windSupport = { sleepWind: false, naturalWind: true }, // wind support on
-    windSetting = { sleepWind: false, naturalWind: false }, // naturalWind defaut to off
-    airflowDirection = FanControl.AirflowDirection.Forward, // Default airflow direction
-  ) {
+    percentSetting: number = 0,
+    percentCurrent: number = 0,
+    speedMax: number = 10,
+    speedSetting: number = 0,
+    speedCurrent: number = 0,
+    rockSupport: { rockLeftRight: boolean; rockUpDown: boolean; rockRound: boolean } = { rockLeftRight: true, rockUpDown: true, rockRound: true },
+    rockSetting: { rockLeftRight: boolean; rockUpDown: boolean; rockRound: boolean } = { rockLeftRight: true, rockUpDown: false, rockRound: false },
+    windSupport: { sleepWind: boolean; naturalWind: boolean } = { sleepWind: true, naturalWind: true },
+    windSetting: { sleepWind: boolean; naturalWind: boolean } = { sleepWind: false, naturalWind: true },
+    airflowDirection: FanControl.AirflowDirection = FanControl.AirflowDirection.Forward,
+  ): this {
     this.behaviors.require(MatterbridgeFanControlServer.with(FanControl.Feature.MultiSpeed, FanControl.Feature.Auto, FanControl.Feature.Step, FanControl.Feature.Rocking, FanControl.Feature.Wind, FanControl.Feature.AirflowDirection), {
+      // Base fan control attributes
       fanMode, // Writable and persistent attribute
       fanModeSequence, // Fixed attribute
       percentSetting, // Writable attribute
@@ -1861,7 +1872,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       // Wind feature
       windSupport, // Fixed attribute
       windSetting, // Writable attribute
-      // airflowDirection
+      // AirflowDirection feature
       airflowDirection, // Writable attribute
     });
     return this;

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1840,20 +1840,13 @@ export class MatterbridgeEndpoint extends Endpoint {
     speedMax = 10,
     speedSetting = 0,
     speedCurrent = 0,
-    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false, }, // Indicate rock left to right support
-    rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false, }, // rockLeftRight default to off
-    windSupport = { sleepWind: false, naturalWind: true, }, // wind support on
-    windSetting = { sleepWind: false, naturalWind: false, }, // naturalWind defaut to off
+    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false }, // Indicate rock left to right support
+    rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false }, // rockLeftRight default to off
+    windSupport = { sleepWind: false, naturalWind: true }, // wind support on
+    windSetting = { sleepWind: false, naturalWind: false }, // naturalWind defaut to off
     airflowDirection = FanControl.AirflowDirection.Forward, // Default airflow direction
   ) {
-    this.behaviors.require(MatterbridgeFanControlServer.with(
-      FanControl.Feature.MultiSpeed,
-      FanControl.Feature.Auto,
-      FanControl.Feature.Step,
-      FanControl.Feature.Rocking,
-      FanControl.Feature.Wind,
-      FanControl.Feature.AirflowDirection,
-    ), {
+    this.behaviors.require(MatterbridgeFanControlServer.with(FanControl.Feature.MultiSpeed, FanControl.Feature.Auto, FanControl.Feature.Step, FanControl.Feature.Rocking, FanControl.Feature.Wind, FanControl.Feature.AirflowDirection), {
       fanMode, // Writable and persistent attribute
       fanModeSequence, // Fixed attribute
       percentSetting, // Writable attribute
@@ -1869,7 +1862,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       windSupport, // Fixed attribute
       windSetting, // Writable attribute
       // airflowDirection
-      airflowDirection // Writable attribute
+      airflowDirection, // Writable attribute
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1817,6 +1817,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {object} [rockSetting] - The rock setting configuration.
    * @param {object} [windSupport] - The wind support configuration.
    * @param {object} [windSetting] - The wind setting configuration.
+   * @param {FanControl.AirflowDirection} [airflowDirection] - The airflow direction. Defaults to `FanControl.AirflowDirection.Forward`.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
    * @remarks
@@ -1829,6 +1830,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * - rockSetting is writable.
    * - windSupport is fixed.
    * - windSetting is writable.
+   * - airflowDirection is writable.
    */
   createCompleteFanControlClusterServer(
     fanMode = FanControl.FanMode.Off,
@@ -1838,9 +1840,9 @@ export class MatterbridgeEndpoint extends Endpoint {
     speedMax = 10,
     speedSetting = 0,
     speedCurrent = 0,
-    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false, }, // Indicate rock left to right
+    rockSupport = { rockLeftRight: true, rockUpDown: false, rockRound: false, }, // Indicate rock left to right support
     rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false, }, // rockLeftRight default to off
-    windSupport = { sleepWind: false, naturalWind: true, }, // Indicate wind on
+    windSupport = { sleepWind: false, naturalWind: true, }, // wind support on
     windSetting = { sleepWind: false, naturalWind: false, }, // naturalWind defaut to off
     airflowDirection = FanControl.AirflowDirection.Forward, // Default airflow direction
   ) {

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1804,7 +1804,7 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a fan control cluster server with features MultiSpeed, Auto, and Step.
+   * Creates a fan control cluster server with features MultiSpeed, Auto, Step, Rock and Wind.
    *
    * @param {FanControl.FanMode} [fanMode] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.
    * @param {FanControl.FanModeSequence} [fanModeSequence] - The fan mode sequence to set. Defaults to `FanControl.FanModeSequence.OffLowMedHighAuto`.

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1804,7 +1804,7 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
-   * Creates a fan control cluster server with features MultiSpeed, Auto, Step, Rock and Wind.
+   * Creates a fan control cluster server with features MultiSpeed, Auto, Step, Rock, Wind and AirflowDirection.
    *
    * @param {FanControl.FanMode} [fanMode] - The fan mode to set. Defaults to `FanControl.FanMode.Off`.
    * @param {FanControl.FanModeSequence} [fanModeSequence] - The fan mode sequence to set. Defaults to `FanControl.FanModeSequence.OffLowMedHighAuto`.
@@ -1842,6 +1842,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     rockSetting = { rockLeftRight: false, rockUpDown: false, rockRound: false, }, // rockLeftRight default to off
     windSupport = { sleepWind: false, naturalWind: true, }, // Indicate wind on
     windSetting = { sleepWind: false, naturalWind: false, }, // naturalWind defaut to off
+    airflowDirection = FanControl.AirflowDirection.Forward, // Default airflow direction
   ) {
     this.behaviors.require(MatterbridgeFanControlServer.with(
       FanControl.Feature.MultiSpeed,
@@ -1849,6 +1850,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       FanControl.Feature.Step,
       FanControl.Feature.Rocking,
       FanControl.Feature.Wind,
+      FanControl.Feature.AirflowDirection,
     ), {
       fanMode, // Writable and persistent attribute
       fanModeSequence, // Fixed attribute
@@ -1864,6 +1866,8 @@ export class MatterbridgeEndpoint extends Endpoint {
       // Wind feature
       windSupport, // Fixed attribute
       windSetting, // Writable attribute
+      // airflowDirection
+      airflowDirection // Writable attribute
     });
     return this;
   }


### PR DESCRIPTION
## Change
Add fan device with all features:
 - FanControl.Feature.MultiSpeed
 - FanControl.Feature.Auto
 - FanControl.Feature.Step
 - FanControl.Feature.Rocking
 - FanControl.Feature.Wind
 - FanControl.Feature.AirflowDirection

It can be used as an example for `matterbridge-example-dynamic-platform`.

### Testing
**Apple Home**
- Wind feature is not supported in Apple Home

**Home Assistant**
<img width="458" height="567" alt="image" src="https://github.com/user-attachments/assets/762aa30c-4c5d-47d7-9616-af7d507f89a0" />
