### PR TITLE
Add countdownTime to OperationalState cluster

### DIFF
--- a/src/matterbridgeEndpointHelpers.ts
+++ b/src/matterbridgeEndpointHelpers.ts
@@ -782,6 +782,7 @@ export function getDefaultOperationalStateClusterServer(operationalState: Operat
   return optionsFor(MatterbridgeOperationalStateServer, {
     phaseList: [],
     currentPhase: null,
+    countdownTime: null,
     operationalStateList: [
       { operationalStateId: OperationalState.OperationalStateEnum.Stopped, operationalStateLabel: 'Stopped' },
       { operationalStateId: OperationalState.OperationalStateEnum.Running, operationalStateLabel: 'Running' },


### PR DESCRIPTION
Add `countdownTime` to OperationalState cluster.
This will allow to change the attribute value in start() method for appliances.

Supported by HA: https://github.com/home-assistant/core/pull/147705