### PR TITLE
Add createDefaultHeatingOccupancyThermostatClusterServer

### DIFF
--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1927,7 +1927,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
       // Thermostat.Feature.Occupancy
       unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
-      occupancy: occupied,
+      occupancy: occupancy,
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1913,7 +1913,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       unoccupiedHeatingSetpoint: number = 18,
       minHeatSetpointLimit: number = 0,
       maxHeatSetpointLimit: number = 50,
-      occupied: boolean = false,
+      occupied?: boolean | undefined = false,
     ): this {
     this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
       localTemperature: localTemperature * 100,

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1904,7 +1904,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {number} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 18°.
    * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
    * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
-   * @param {boolean | undefined} [occupied] - A boolean indicating whether the occupancy is occupied or not. Default is false.
+   * @param {{boolean | undefined}} [occupancy] - A boolean indicating whether the occupancy is occupied or not. Default is false.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultHeatingOccupancyThermostatClusterServer(
@@ -1913,7 +1913,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     unoccupiedHeatingSetpoint: number = 18,
     minHeatSetpointLimit: number = 0,
     maxHeatSetpointLimit: number = 50,
-    occupied: boolean | undefined = false,
+    occupancy: boolean | undefined = false,
   ): this {
     this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
       localTemperature: localTemperature * 100,

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1908,13 +1908,13 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultHeatingOccupancyThermostatClusterServer(
-      localTemperature: number = 23,
-      occupiedHeatingSetpoint: number = 21,
-      unoccupiedHeatingSetpoint: number = 18,
-      minHeatSetpointLimit: number = 0,
-      maxHeatSetpointLimit: number = 50,
-      occupied: boolean | undefined = false,
-    ): this {
+    localTemperature: number = 23,
+    occupiedHeatingSetpoint: number = 21,
+    unoccupiedHeatingSetpoint: number = 18,
+    minHeatSetpointLimit: number = 0,
+    maxHeatSetpointLimit: number = 50,
+    occupied: boolean | undefined = false,
+  ): this {
     this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
       localTemperature: localTemperature * 100,
       systemMode: Thermostat.SystemMode.Heat,
@@ -1926,8 +1926,8 @@ export class MatterbridgeEndpoint extends Endpoint {
       absMinHeatSetpointLimit: minHeatSetpointLimit * 100,
       absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
       // Thermostat.Feature.Occupancy
-  	  unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
-  	  occupancy: occupied,
+      unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
+      occupancy: occupied,
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1927,7 +1927,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
       // Thermostat.Feature.Occupancy
   	  unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
-  	  occupied?: boolean | undefined ?? occupied,
+  	  occupancy: occupied,
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1904,7 +1904,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {number} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 18°.
    * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
    * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
-   * @param {{boolean | undefined}} [occupancy] - A boolean indicating whether the occupancy is occupied or not. Default is false.
+   * @param {boolean} [occupancy] - A boolean indicating whether the occupancy is occupied or not. Default is false.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultHeatingOccupancyThermostatClusterServer(
@@ -1913,7 +1913,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     unoccupiedHeatingSetpoint: number = 18,
     minHeatSetpointLimit: number = 0,
     maxHeatSetpointLimit: number = 50,
-    occupancy: boolean | undefined = false,
+    occupancy: boolean = true,
   ): this {
     this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
       localTemperature: localTemperature * 100,

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1927,7 +1927,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
       // Thermostat.Feature.Occupancy
   	  unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
-  	  occupancy: occupied,
+  	  occupied?: boolean | undefined ?? occupied,
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1897,6 +1897,42 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
+   * Creates a default heating thermostat cluster server with Heating and Occupancy features.
+   *
+   * @param {number} [localTemperature] - The local temperature value in degrees Celsius. Defaults to 23°.
+   * @param {number} [occupiedHeatingSetpoint] - The occupied heating setpoint value in degrees Celsius. Defaults to 21°.
+   * @param {number} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 18°.
+   * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
+   * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
+   * @param {number} [occupied] - A boolean indicating whether the occupancy is occupied or not. Default is false.
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   */
+  createDefaultHeatingOccupancyThermostatClusterServer(
+      localTemperature: number = 23,
+      occupiedHeatingSetpoint: number = 21,
+      unoccupiedHeatingSetpoint: number = 18,
+      minHeatSetpointLimit: number = 0,
+      maxHeatSetpointLimit: number = 50,
+      occupied: boolean = false,
+    ): this {
+    this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
+      localTemperature: localTemperature * 100,
+      systemMode: Thermostat.SystemMode.Heat,
+      controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.HeatingOnly,
+      // Thermostat.Feature.Heating
+      occupiedHeatingSetpoint: occupiedHeatingSetpoint * 100,
+      minHeatSetpointLimit: minHeatSetpointLimit * 100,
+      maxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+      absMinHeatSetpointLimit: minHeatSetpointLimit * 100,
+      absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+      // Thermostat.Feature.Occupancy
+  	  unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
+  	  occupancy: occupied,
+    });
+    return this;
+  }
+
+  /**
    * Creates a default cooling thermostat cluster server with feature Cooling.
    *
    * @param {number} [localTemperature] - The local temperature value in degrees Celsius. Defaults to 23°.

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1904,7 +1904,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {number} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 18°.
    * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
    * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
-   * @param {boolean} [occupancy] - A boolean indicating whether the occupancy is occupied or not. Default is false.
+   * @param {occupancy} [occupancy] - A boolean indicating whether the occupancy is occupied or not. Default is false.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultHeatingOccupancyThermostatClusterServer(
@@ -1927,7 +1927,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
       // Thermostat.Feature.Occupancy
       unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint * 100,
-      occupancy: occupancy,
+      occupancy: { occupied: occupancy },
     });
     return this;
   }

--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -1904,7 +1904,7 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {number} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 18°.
    * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
    * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
-   * @param {number} [occupied] - A boolean indicating whether the occupancy is occupied or not. Default is false.
+   * @param {boolean | undefined} [occupied] - A boolean indicating whether the occupancy is occupied or not. Default is false.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    */
   createDefaultHeatingOccupancyThermostatClusterServer(
@@ -1913,7 +1913,7 @@ export class MatterbridgeEndpoint extends Endpoint {
       unoccupiedHeatingSetpoint: number = 18,
       minHeatSetpointLimit: number = 0,
       maxHeatSetpointLimit: number = 50,
-      occupied?: boolean | undefined = false,
+      occupied: boolean | undefined = false,
     ): this {
     this.behaviors.require(MatterbridgeThermostatServer.with(Thermostat.Feature.Heating, Thermostat.Feature.Occupancy), {
       localTemperature: localTemperature * 100,


### PR DESCRIPTION
## Proposed change

Creates a default heating thermostat cluster server with `Heating`and `Occupancy` features.
When enabled, thermostat is following the occupancy signal.

**iOS support**
https://support.apple.com/guide/iphone/iphdf6fde3d8/ios

## Additional information

- This PR fixes or closes issue: fixes [#969](https://github.com/Luligu/matterbridge/issues/394)

