### PR TITLE
Creates a default Electrical Apparent Power Measurement Cluster Server

### DIFF
--- a/src/matterbridgeEndpoint.ts
+++ b/src/matterbridgeEndpoint.ts
@@ -2815,6 +2815,57 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
+   * Creates a default Electrical Apparent Power Measurement Cluster Server with features AlternatingCurrent.
+   *
+   * @param {number} voltage - The voltage value in millivolts.
+   * @param {number} apparentCurrent - The current value in milliamperes.
+   * @param {number} apparentPower - The apparent power value in millivoltamperes.
+   * @param {number} frequency - The frequency value in millihertz.
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   */
+  createDefaultElectricalActivePowerMeasurementClusterServer(voltage: number | bigint | null = null, apparentCurrent: number | bigint | null = null, apparentPower: number | bigint | null = null, frequency: number | bigint | null = null): this {
+    this.behaviors.require(ElectricalPowerMeasurementServer.with(ElectricalPowerMeasurement.Feature.AlternatingCurrent), {
+      powerMode: ElectricalPowerMeasurement.PowerMode.Ac,
+      numberOfMeasurementTypes: 4,
+      accuracy: [
+        {
+          measurementType: MeasurementType.Voltage,
+          measured: true,
+          minMeasuredValue: Number.MIN_SAFE_INTEGER,
+          maxMeasuredValue: Number.MAX_SAFE_INTEGER,
+          accuracyRanges: [{ rangeMin: Number.MIN_SAFE_INTEGER, rangeMax: Number.MAX_SAFE_INTEGER, fixedMax: 1 }],
+        },
+        {
+          measurementType: MeasurementType.ApparentCurrent,
+          measured: true,
+          minMeasuredValue: Number.MIN_SAFE_INTEGER,
+          maxMeasuredValue: Number.MAX_SAFE_INTEGER,
+          accuracyRanges: [{ rangeMin: Number.MIN_SAFE_INTEGER, rangeMax: Number.MAX_SAFE_INTEGER, fixedMax: 1 }],
+        },
+        {
+          measurementType: MeasurementType.ApparentPower,
+          measured: true,
+          minMeasuredValue: Number.MIN_SAFE_INTEGER,
+          maxMeasuredValue: Number.MAX_SAFE_INTEGER,
+          accuracyRanges: [{ rangeMin: Number.MIN_SAFE_INTEGER, rangeMax: Number.MAX_SAFE_INTEGER, fixedMax: 1 }],
+        },
+        {
+          measurementType: MeasurementType.Frequency,
+          measured: true,
+          minMeasuredValue: Number.MIN_SAFE_INTEGER,
+          maxMeasuredValue: Number.MAX_SAFE_INTEGER,
+          accuracyRanges: [{ rangeMin: Number.MIN_SAFE_INTEGER, rangeMax: Number.MAX_SAFE_INTEGER, fixedMax: 1 }],
+        },
+      ],
+      voltage: voltage,
+      apparentCurrent: apparentCurrent,
+      apparentPower: apparentPower,
+      frequency: frequency,
+    });
+    return this;
+  }
+
+  /**
    * Creates a default TemperatureMeasurement cluster server.
    *
    * @param {number | null} measuredValue - The measured value of the temperature x 100.


### PR DESCRIPTION
## Proposal

Add ElectricalApparentPowerMeasurementClusterServer for Non-Linear Loads.


### Def

You should measure apparent power in the following cases:

1. Alternating Current (AC) Circuits
- Apparent power is particularly relevant in AC circuits, where both active (real) power and reactive power are present. Measuring apparent power helps you understand the overall capacity of the electrical system, as it accounts for the total power being supplied.

2. Systems with Non-Linear Loads
- In systems with non-linear loads, such as rectifiers or electronic devices, the current waveform may be distorted. In these cases, apparent power helps assess the total power demand from the electrical system, including the effects of harmonics.

3. When Using Transformers or Generators
- For sizing transformers, generators, and other electrical equipment, it's essential to consider apparent power (measured in volt-amperes, VA). Apparent power dictates the total power transfer capacity and ensures that equipment can handle both active and reactive loads effectively.

## Testing

<img width="307" height="357" alt="image" src="https://github.com/user-attachments/assets/af8ba898-0d84-48f0-8dbc-23eed4df285b" />