### PR TITLE
Thermostat Units Fahrenheit to Celsius Conversion

### DIFF
--- a/src/devices/temperatureControl.ts
+++ b/src/devices/temperatureControl.ts
@@ -76,27 +76,18 @@ export class MatterbridgeNumberTemperatureControlServer extends TemperatureContr
     const device = this.endpoint.stateOf(MatterbridgeServer);
     device.log.info(`SetTemperature (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
     device.commandHandler.executeHandler('setTemperature', { request, cluster: TemperatureControlServer.id, attributes: this.state, endpoint: this.endpoint });
-
     let targetTemp = request.targetTemperature;
-
     if (targetTemp !== undefined) {
       const maxC = this.state.maxTemperature;
       const minC = this.state.minTemperature;
-
-      // If supplied temperature is higher than Max Celsius (suggesting it's Fahrenheit)
       if (targetTemp > maxC) {
-        // Convert Fahrenheit to Celsius: (F - 32) * 5/9
-        // We divide by 100 and multiply by 100 to maintain the "centidegree" format
         const converted = Math.round(((targetTemp / 100 - 32) * 5 / 9) * 100);
-
-        // Verify if the converted value falls within the valid Celsius range
         if (converted >= minC && converted <= maxC) {
           device.log.warn(`Detected likely Fahrenheit value (${targetTemp}). Correcting to Celsius (${converted}).`);
           targetTemp = converted;
         }
       }
     }
-
     if (targetTemp !== undefined && targetTemp >= this.state.minTemperature && targetTemp <= this.state.maxTemperature) {
       device.log.debug(`MatterbridgeNumberTemperatureControlServer: setTemperature called setting temperatureSetpoint to ${targetTemp}`);
       this.state.temperatureSetpoint = targetTemp;


### PR DESCRIPTION
This is a recommended heuristic fix to vendor controller devices improperly supplying Fahrenheit temperature targets as if they were Celsius intentions. Specifically, Google Nest speakers are improperly supplying target temperatures. 

With this bug if I say "Hey Google, set the thermostat to 70," but do not specify the units as F, it will set the temperature to 70 C (158 F) instead of the desired 70 F (21 C). The thermostat caps heating to 100 F.

Most consumer thermostats have a range of 40°F and 100°F, which is 4°C to 38°C. Because these numbers never overlap, and there is the additional protection of a max and minimum range definition, if a number is supplied outside this min/max range but can be translated to a number inside of this range, it is most certainly the intended target.

This fix applies the following error correction logic:

`If ( supplied_temperature > max_temp_celsius ) and ((( supplied_temperature - 32 ) / ( 9 / 5 )) >= min_temp_celsius) and ((( supplied_temperature - 32 ) / ( 9 / 5 )) <= max_temp_celsius)    { set temperature_target_celsius = (( supplied_temperature - 32 ) / ( 9 / 5 )) }`

This bug needs to be reviewed and tested by a developer with more knowledge. The logic holds, but the code is outside of my professional skill set. 