### PR TITLE
feat: add plugin version selection and fetch available versions from npm

### DIFF
--- a/frontend/src/components/HomeInstallAddPlugins.tsx
+++ b/frontend/src/components/HomeInstallAddPlugins.tsx
@@ -119,13 +119,7 @@ function HomeInstallAddPlugins() {
     setPluginVersion('latest');
 
     // Check if we should fetch versions
-    const shouldFetchVersions =
-      pluginName !== '' &&
-      pluginName.startsWith('matterbridge-') &&
-      !pluginName.includes('@') &&
-      !pluginName.startsWith('/') &&
-      !pluginName.startsWith('./') &&
-      !pluginName.startsWith('file:');
+    const shouldFetchVersions = pluginName !== '' && pluginName.startsWith('matterbridge-') && !pluginName.includes('@') && !pluginName.startsWith('/') && !pluginName.startsWith('./') && !pluginName.startsWith('file:');
 
     if (!shouldFetchVersions) {
       setAvailableVersions([]);
@@ -319,15 +313,7 @@ function HomeInstallAddPlugins() {
                 value={pluginVersion}
                 label='Plugin Version'
                 onChange={(event) => setPluginVersion(event.target.value)}
-                disabled={
-                  pluginName === '' ||
-                  pluginName.includes('@') ||
-                  pluginName.startsWith('/') ||
-                  pluginName.startsWith('./') ||
-                  pluginName.startsWith('file:') ||
-                  availableVersions.length === 0 ||
-                  loadingVersions
-                }
+                disabled={pluginName === '' || pluginName.includes('@') || pluginName.startsWith('/') || pluginName.startsWith('./') || pluginName.startsWith('file:') || availableVersions.length === 0 || loadingVersions}
                 displayEmpty
               >
                 <MenuItem value='latest'>


### PR DESCRIPTION

<img width="1495" height="468" alt="image" src="https://github.com/user-attachments/assets/2f0254d9-3b6e-4f82-91c9-2624862fcb7c" />

This pull request enhances the plugin installation UI by allowing users to select a specific version of a plugin to install, rather than always installing the latest version. It introduces a version dropdown that fetches available versions from the npm registry and updates the backend API calls to include the selected version.

**New plugin version selection feature:**

* Added a dropdown (`Select` component) for choosing a plugin version, which is populated by fetching available versions from the npm registry using the new `fetchPackageVersions` function. The dropdown is automatically updated when the plugin name changes and is disabled for invalid names or while loading. [[1]](diffhunk://#diff-2b1cb217fe6760e62e6fbf00861cd72762c363b285c864e13ed755cba5544b7aL2-R12) [[2]](diffhunk://#diff-2b1cb217fe6760e62e6fbf00861cd72762c363b285c864e13ed755cba5544b7aR42-R148) [[3]](diffhunk://#diff-2b1cb217fe6760e62e6fbf00861cd72762c363b285c864e13ed755cba5544b7aR312-R344)

**Backend integration updates:**

* Updated the install and add plugin actions to include the selected version in the package name (e.g., `plugin@version`) when sending API requests, ensuring the backend installs the correct version. [[1]](diffhunk://#diff-2b1cb217fe6760e62e6fbf00861cd72762c363b285c864e13ed755cba5544b7aR212-R217) [[2]](diffhunk://#diff-2b1cb217fe6760e62e6fbf00861cd72762c363b285c864e13ed755cba5544b7aR229-R234)