### PR TITLE
fix: point package entrypoints to exported build

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "ewelink"
   ],
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/export.js",
+  "types": "dist/export.d.ts",
   "bin": {
     "matterbridge": "bin/matterbridge.js",
     "mb-mdns": "bin/mb_mdns.js",


### PR DESCRIPTION
## Summary
- update the root `main` and `types` package entrypoints to the build artifacts that are actually exported and published
- align them with the existing root `exports` map (`dist/export.js` / `dist/export.d.ts`)

## Why
The published `matterbridge@3.9.0` package contains `dist/export.js` and `dist/export.d.ts`, but not `dist/index.js` or `dist/index.d.ts`. Tools that still read `main`/`types` can resolve missing files.

## Validation
- `node -e "const p=require('./package.json'); if(p.main!=='dist/export.js'||p.types!=='dist/export.d.ts') process.exit(1); if(p.exports['.'].import !== './'+p.main) process.exit(2); if(p.exports['.'].types !== './'+p.types) process.exit(3)"`
- `git diff --check`