### PR TITLE
fix: remove missing utils zip export

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -118,10 +118,6 @@
       "types": "./dist/createDirectory.d.ts",
       "import": "./dist/createDirectory.js"
     },
-    "./zip": {
-      "types": "./dist/createZip.d.ts",
-      "import": "./dist/createZip.js"
-    },
     "./color-utils": {
       "types": "./dist/colorUtils.d.ts",
       "import": "./dist/colorUtils.js"


### PR DESCRIPTION
## Summary
- remove the `@matterbridge/utils` `./zip` subpath export
- that subpath points to `dist/createZip.js` / `dist/createZip.d.ts`, which are not built or published

## Why
`@matterbridge/utils@3.9.0` advertises `./zip`, but the package tarball contains no `dist/createZip.*` files and the workspace has no `packages/utils/src/createZip.ts` source file. Importing that subpath resolves to missing files.

## Validation
- `npm pack @matterbridge/utils@3.9.0 --silent` confirmed `package/dist/createZip.js` and `package/dist/createZip.d.ts` are absent
- `node -e "const p=require('./packages/utils/package.json'); if(p.exports['./zip']) process.exit(1)"`
- `git diff --check`