### PR TITLE
Chime device type: behavior, endpoint helper, and client cluster mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ These classes will run as threads in the next releases:
 - all plugins in bridge mode;
 - each plugin in childbridge mode;
 
+## [3.9.5] - Dev branch
+
+### Added
+
+- [chime]: Add `MatterbridgeChimeServer` behavior and `createDefaultChimeClusterServer()` endpoint helper for the Chime device type.
+- [chime]: Map the Chime client cluster to `ChimeClient` so the Doorbell device type resolves a working client binding.
+
+<a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
+
 ## [3.9.4] - 2026-07-10
 
 ### Added

--- a/packages/core/src/behaviors/chimeServer.ts
+++ b/packages/core/src/behaviors/chimeServer.ts
@@ -1,0 +1,58 @@
+/**
+ * @file packages/core/src/behaviors/chimeServer.ts
+ * @description This file contains the MatterbridgeChimeServer class of Matterbridge.
+ * @author Luca Liguori
+ * @created 2026-07-06
+ * @version 1.0.0
+ * @license Apache-2.0
+ *
+ * Copyright 2026, 2027, 2028 Luca Liguori.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* oxlint-disable typescript/no-unsafe-type-assertion */
+
+import { ChimeServer } from '@matter/node/behaviors/chime';
+import type { Chime } from '@matter/types/clusters/chime';
+
+import type { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
+import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandler.js';
+import { MatterbridgeServer } from './matterbridgeServer.js';
+
+/**
+ * Chime server that forwards the PlayChimeSound command to the Matterbridge command handler and generates the ChimeStartedPlaying event.
+ */
+export class MatterbridgeChimeServer extends ChimeServer {
+  /**
+   * Handles the PlayChimeSound command.
+   * Plays the chime sound passed in the request or, if none is passed, the currently selected chime, and generates the ChimeStartedPlaying event.
+   *
+   * @param {Chime.PlayChimeSoundRequest} request - PlayChimeSound request payload.
+   */
+  override async playChimeSound(request: Chime.PlayChimeSoundRequest): Promise<void> {
+    const device = this.endpoint.stateOf(MatterbridgeServer);
+    const chimeId = request.chimeId ?? this.state.selectedChime;
+    device.log.info(`Playing chime sound ${chimeId} (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+    await device.commandHandler.executeHandler('Chime.playChimeSound', {
+      command: 'playChimeSound',
+      request,
+      cluster: ChimeServer.id,
+      attributes: this.state as unknown as ClusterAttributeValues<(typeof Chime)['attributes']>,
+      endpoint: this.endpoint as MatterbridgeEndpoint,
+      context: this.context,
+    });
+    device.log.debug(`MatterbridgeChimeServer: playChimeSound called with chimeId ${chimeId}`);
+    this.events.chimeStartedPlaying.emit({ chimeId }, this.context);
+  }
+}

--- a/packages/core/src/behaviors/chimeServer.ts
+++ b/packages/core/src/behaviors/chimeServer.ts
@@ -27,7 +27,6 @@ import { ChimeServer } from '@matter/node/behaviors/chime';
 import type { Chime } from '@matter/types/clusters/chime';
 
 import type { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
-import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandler.js';
 import { MatterbridgeServer } from './matterbridgeServer.js';
 
 /**
@@ -48,7 +47,7 @@ export class MatterbridgeChimeServer extends ChimeServer {
       command: 'playChimeSound',
       request,
       cluster: ChimeServer.id,
-      attributes: this.state as unknown as ClusterAttributeValues<(typeof Chime)['attributes']>,
+      attributes: this.state,
       endpoint: this.endpoint as MatterbridgeEndpoint,
       context: this.context,
     });

--- a/packages/core/src/behaviors/export.ts
+++ b/packages/core/src/behaviors/export.ts
@@ -26,6 +26,7 @@
 export * from './activatedCarbonFilterMonitoringServer.js';
 export * from './bindingServer.js';
 export * from './booleanStateConfigurationServer.js';
+export * from './chimeServer.js';
 export * from './colorControlServer.js';
 export * from './deviceEnergyManagementModeServer.js';
 export * from './deviceEnergyManagementServer.js';

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -67,6 +67,7 @@ import { type ClusterType, type ClusterTyping, getClusterNameById } from '@matte
 import { AirQuality } from '@matter/types/clusters/air-quality';
 import { BooleanStateConfiguration } from '@matter/types/clusters/boolean-state-configuration';
 import { BridgedDeviceBasicInformation } from '@matter/types/clusters/bridged-device-basic-information';
+import type { Chime } from '@matter/types/clusters/chime';
 import { ColorControl } from '@matter/types/clusters/color-control';
 import { ConcentrationMeasurement } from '@matter/types/clusters/concentration-measurement';
 import { Descriptor } from '@matter/types/clusters/descriptor';
@@ -104,6 +105,7 @@ import { AnsiLogger, CYAN, db, debugStringify, hk, LogLevel, or, TimestampFormat
 // matterbridge
 import { MatterbridgeActivatedCarbonFilterMonitoringServer } from './behaviors/activatedCarbonFilterMonitoringServer.js';
 import { MatterbridgeBooleanStateConfigurationServer } from './behaviors/booleanStateConfigurationServer.js';
+import { MatterbridgeChimeServer } from './behaviors/chimeServer.js';
 import { MatterbridgeColorControlServer } from './behaviors/colorControlServer.js';
 import { MatterbridgeDeviceEnergyManagementModeServer } from './behaviors/deviceEnergyManagementModeServer.js';
 import { MatterbridgeDeviceEnergyManagementServer } from './behaviors/deviceEnergyManagementServer.js';
@@ -3938,6 +3940,28 @@ export class MatterbridgeEndpoint extends Endpoint {
       {
         numberOfPositions: 2,
         currentPosition: 0,
+      },
+    );
+    return this;
+  }
+
+  /**
+   * Creates a default Chime cluster server.
+   *
+   * @param {Chime.ChimeSound[]} [installedChimeSounds] - The list of installed chime sounds (default: a single 'Default' chime sound with ChimeID 0).
+   * @param {number} [selectedChime] - The ChimeID, within installedChimeSounds, of the chime sound played when PlayChimeSound is invoked without an explicit ChimeID (default: 0).
+   * @param {boolean} [enabled] - Whether chime sounds can currently be played (default: true).
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   */
+  createDefaultChimeClusterServer(installedChimeSounds: Chime.ChimeSound[] = [{ chimeId: 0, name: 'Default' }], selectedChime: number = 0, enabled: boolean = true): this {
+    this.behaviors.require(
+      MatterbridgeChimeServer.enable({
+        events: { chimeStartedPlaying: true },
+      }),
+      {
+        installedChimeSounds,
+        selectedChime,
+        enabled,
       },
     );
     return this;

--- a/packages/core/src/matterbridgeEndpointCommandHandler.ts
+++ b/packages/core/src/matterbridgeEndpointCommandHandler.ts
@@ -31,6 +31,7 @@ import type { ActionContext } from '@matter/main';
 import type { ClusterType } from '@matter/types/cluster';
 import type { ActivatedCarbonFilterMonitoring } from '@matter/types/clusters/activated-carbon-filter-monitoring';
 import type { BooleanStateConfiguration } from '@matter/types/clusters/boolean-state-configuration';
+import type { Chime } from '@matter/types/clusters/chime';
 import type { ColorControl } from '@matter/types/clusters/color-control';
 import type { DeviceEnergyManagement } from '@matter/types/clusters/device-energy-management';
 import type { DeviceEnergyManagementMode } from '@matter/types/clusters/device-energy-management-mode';
@@ -134,6 +135,9 @@ export interface MatterbridgeEndpointCommands {
   // Valve Configuration and Control
   open: HandlerFunction;
   close: HandlerFunction;
+
+  // Chime
+  playChimeSound: HandlerFunction;
 
   // Boolean State Configuration
   suppressAlarm: HandlerFunction;
@@ -711,6 +715,16 @@ export type CommandHandlerDataMap = {
     request: {}; // TlvNoArguments
     cluster: 'valveConfigurationAndControl';
     attributes: ClusterAttributeValues<(typeof ValveConfigurationAndControl)['attributes']>;
+    endpoint: MatterbridgeEndpoint;
+  };
+
+  // Chime
+  'playChimeSound': CommandHandlerData<'Chime.playChimeSound'>;
+  'Chime.playChimeSound': {
+    command: 'playChimeSound';
+    request: Chime.PlayChimeSoundRequest;
+    cluster: 'chime';
+    attributes: ClusterAttributeValues<(typeof Chime)['attributes']>;
     endpoint: MatterbridgeEndpoint;
   };
 

--- a/packages/core/src/matterbridgeEndpointHelpers.ts
+++ b/packages/core/src/matterbridgeEndpointHelpers.ts
@@ -700,6 +700,7 @@ export function addClusterServers(endpoint: MatterbridgeEndpoint, serverList: Cl
   if (serverList.includes(PumpConfigurationAndControl.id)) endpoint.createDefaultPumpConfigurationAndControlClusterServer();
   if (serverList.includes(SmokeCoAlarm.id)) endpoint.createDefaultSmokeCOAlarmClusterServer();
   if (serverList.includes(Switch.id)) endpoint.createDefaultSwitchClusterServer();
+  if (serverList.includes(Chime.id)) endpoint.createDefaultChimeClusterServer();
   if (serverList.includes(OperationalState.id)) endpoint.createDefaultOperationalStateClusterServer();
   if (serverList.includes(BooleanState.id)) endpoint.createDefaultBooleanStateClusterServer();
   if (serverList.includes(BooleanStateConfiguration.id)) endpoint.createDefaultBooleanStateConfigurationClusterServer();

--- a/packages/core/src/matterbridgeEndpointHelpers.ts
+++ b/packages/core/src/matterbridgeEndpointHelpers.ts
@@ -44,6 +44,7 @@ import { BooleanStateServer } from '@matter/node/behaviors/boolean-state';
 import { BridgedDeviceBasicInformationServer } from '@matter/node/behaviors/bridged-device-basic-information';
 import { CarbonDioxideConcentrationMeasurementServer } from '@matter/node/behaviors/carbon-dioxide-concentration-measurement';
 import { CarbonMonoxideConcentrationMeasurementServer } from '@matter/node/behaviors/carbon-monoxide-concentration-measurement';
+import { ChimeClient } from '@matter/node/behaviors/chime';
 import { ColorControlClient } from '@matter/node/behaviors/color-control';
 import { DoorLockClient } from '@matter/node/behaviors/door-lock';
 import { ElectricalEnergyMeasurementServer } from '@matter/node/behaviors/electrical-energy-measurement';
@@ -89,6 +90,7 @@ import { BooleanStateConfiguration } from '@matter/types/clusters/boolean-state-
 import { BridgedDeviceBasicInformation } from '@matter/types/clusters/bridged-device-basic-information';
 import { CarbonDioxideConcentrationMeasurement } from '@matter/types/clusters/carbon-dioxide-concentration-measurement';
 import { CarbonMonoxideConcentrationMeasurement } from '@matter/types/clusters/carbon-monoxide-concentration-measurement';
+import { Chime } from '@matter/types/clusters/chime';
 import { ColorControl } from '@matter/types/clusters/color-control';
 import { DeviceEnergyManagement } from '@matter/types/clusters/device-energy-management';
 import { DeviceEnergyManagementMode } from '@matter/types/clusters/device-energy-management-mode';
@@ -489,6 +491,7 @@ export function getBehaviourTypeFromClusterClientId(clusterId: ClusterId): Clust
   if (clusterId === OnOff.id) return OnOffClient;
   if (clusterId === LevelControl.id) return LevelControlClient;
   if (clusterId === ColorControl.id) return ColorControlClient;
+  if (clusterId === Chime.id) return ChimeClient;
   if (clusterId === OccupancySensing.id) return OccupancySensingClient;
   if (clusterId === ScenesManagement.id) return ScenesManagementClient;
   if (clusterId === DoorLock.id) return DoorLockClient;

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -41,6 +41,7 @@ import {
   BooleanState,
   BooleanStateConfiguration,
   BridgedDeviceBasicInformation,
+  Chime,
   ColorControl,
   DeviceEnergyManagement,
   DeviceEnergyManagementMode,
@@ -94,6 +95,7 @@ import { BLUE, db, er, hk, LogLevel, or } from 'node-ansi-logger';
 import {
   airPurifier,
   airQualitySensor,
+  chime,
   contactSensor,
   doorLock,
   electricalSensor,
@@ -1601,6 +1603,21 @@ describe('Matterbridge ' + NAME, () => {
     await add(device);
     expect(device.getAttribute(ValveConfigurationAndControl.id, 'currentState')).toBe(ValveConfigurationAndControl.ValveState.Closed);
     expect(device.getAttribute(ValveConfigurationAndControl.id, 'currentLevel')).toBe(0);
+    // (matterbridge.frontend as any).getClusterTextFromDevice(device);
+  });
+
+  test('createDefaultChimeClusterServer', async () => {
+    const device = new MatterbridgeEndpoint(chime, { id: 'Chime' });
+    expect(device).toBeDefined();
+    device.createDefaultChimeClusterServer();
+    expect(device.hasAttributeServer(Chime, 'installedChimeSounds')).toBe(true);
+    expect(device.hasAttributeServer(Chime, 'selectedChime')).toBe(true);
+    expect(device.hasAttributeServer(Chime, 'enabled')).toBe(true);
+
+    await add(device);
+    expect(device.getAttribute(Chime.id, 'installedChimeSounds')).toEqual([{ chimeId: 0, name: 'Default' }]);
+    expect(device.getAttribute(Chime.id, 'selectedChime')).toBe(0);
+    expect(device.getAttribute(Chime.id, 'enabled')).toBe(true);
     // (matterbridge.frontend as any).getClusterTextFromDevice(device);
   });
 

--- a/packages/core/vitest/matterbridgeEndpoint-matterjs.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-matterjs.test.ts
@@ -26,6 +26,7 @@ import { Endpoint } from '@matter/node';
 import {
   BooleanStateConfigurationServer,
   BooleanStateServer,
+  ChimeServer,
   ColorControlServer,
   DescriptorBehavior,
   DescriptorServer,
@@ -96,6 +97,7 @@ import { createServerNode, createTestEnvironment, destroyTestEnvironment, flushS
 import { AnsiLogger, debugStringify, er, hk, LogLevel } from 'node-ansi-logger';
 
 import { MatterbridgeBooleanStateConfigurationServer } from '../src/behaviors/booleanStateConfigurationServer.js';
+import { MatterbridgeChimeServer } from '../src/behaviors/chimeServer.js';
 import { MatterbridgeColorControlServer } from '../src/behaviors/colorControlServer.js';
 import { MatterbridgeDeviceEnergyManagementModeServer } from '../src/behaviors/deviceEnergyManagementModeServer.js';
 import { MatterbridgeDeviceEnergyManagementServer } from '../src/behaviors/deviceEnergyManagementServer.js';
@@ -114,6 +116,7 @@ import { Evse, MatterbridgeEnergyEvseServer } from '../src/devices/evse.js';
 import { MatterbridgeRvcCleanModeServer, MatterbridgeRvcOperationalStateServer, MatterbridgeRvcRunModeServer, RoboticVacuumCleaner } from '../src/devices/roboticVacuumCleaner.js';
 import { WaterHeater } from '../src/devices/waterHeater.js';
 import {
+  chime,
   doorLock,
   extendedColorLight,
   fan,
@@ -148,6 +151,7 @@ describe('Matterbridge ' + NAME, () => {
   let vent: MatterbridgeEndpoint;
   let thermo: MatterbridgeEndpoint;
   let valve: MatterbridgeEndpoint;
+  let chimeDevice: MatterbridgeEndpoint;
   let mode: MatterbridgeEndpoint;
   let smoke: MatterbridgeEndpoint;
   let leak: MatterbridgeEndpoint;
@@ -361,6 +365,14 @@ describe('Matterbridge ' + NAME, () => {
     expect(valve).toBeDefined();
     expect(valve.id).toBe('WaterValve');
     expect(valve.getAllClusterServerNames()).toEqual(['descriptor', 'matterbridge', 'identify', 'valveConfigurationAndControl']);
+  });
+
+  test('create a chime device', () => {
+    chimeDevice = new MatterbridgeEndpoint(chime, { id: 'Chime' });
+    chimeDevice.addRequiredClusterServers();
+    expect(chimeDevice).toBeDefined();
+    expect(chimeDevice.id).toBe('Chime');
+    expect(chimeDevice.getAllClusterServerNames()).toEqual(['descriptor', 'matterbridge', 'chime']);
   });
 
   test('create a mode device', () => {
@@ -580,6 +592,11 @@ describe('Matterbridge ' + NAME, () => {
   test('add valve device to serverNode', async () => {
     expect(await server.add(valve)).toBeDefined();
     // (matterbridge as any).frontend.getClusterTextFromDevice(valve);
+  });
+
+  test('add chime device to serverNode', async () => {
+    expect(await server.add(chimeDevice)).toBeDefined();
+    // (matterbridge as any).frontend.getClusterTextFromDevice(chimeDevice);
   });
 
   test('add mode device to serverNode', async () => {
@@ -1203,6 +1220,19 @@ describe('Matterbridge ' + NAME, () => {
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Closing valve (endpoint ${valve.id}.${valve.number})`);
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, expect.stringContaining(`MatterbridgeValveConfigurationAndControlServer: open called`));
     expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `MatterbridgeValveConfigurationAndControlServer: close called`);
+  });
+
+  test('invoke MatterbridgeChimeServer commands', async () => {
+    expect(chimeDevice.behaviors.has(ChimeServer)).toBeTruthy();
+    expect(chimeDevice.behaviors.has(MatterbridgeChimeServer)).toBeTruthy();
+    expect(chimeDevice.behaviors.elementsOf(MatterbridgeChimeServer).commands.has('playChimeSound')).toBeTruthy();
+    expect((chimeDevice.stateOf(MatterbridgeChimeServer) as any).acceptedCommandList).toEqual([0]);
+    expect((chimeDevice.stateOf(MatterbridgeChimeServer) as any).generatedCommandList).toEqual([]);
+    expect((chimeDevice.stateOf(MatterbridgeChimeServer) as any).installedChimeSounds).toEqual([{ chimeId: 0, name: 'Default' }]);
+    await chimeDevice.invokeBehaviorCommand('chime', 'playChimeSound', {});
+    await chimeDevice.invokeBehaviorCommand('chime', 'playChimeSound', { chimeId: 0 });
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.INFO, `Playing chime sound 0 (endpoint ${chimeDevice.id}.${chimeDevice.number})`);
+    expect(loggerLogSpy).toHaveBeenCalledWith(LogLevel.DEBUG, `MatterbridgeChimeServer: playChimeSound called with chimeId 0`);
   });
 
   test('invoke MatterbridgeSmokeCoAlarmServer commands', async () => {

--- a/packages/core/vitest/matterbridgeEndpointHelpers.test.ts
+++ b/packages/core/vitest/matterbridgeEndpointHelpers.test.ts
@@ -18,6 +18,7 @@ import { CommonNumberTag, PowerSourceTag } from '@matter/node';
 import { DescriptorServer } from '@matter/node/behaviors/descriptor';
 import { TemperatureMeasurementServer } from '@matter/node/behaviors/temperature-measurement';
 import { VendorId } from '@matter/types';
+import { Chime } from '@matter/types/clusters/chime';
 import { ClosureControl } from '@matter/types/clusters/closure-control';
 import { DoorLock } from '@matter/types/clusters/door-lock';
 import { FlowMeasurement } from '@matter/types/clusters/flow-measurement';
@@ -38,7 +39,7 @@ import { db, er, hk, or, wr } from 'node-ansi-logger';
 
 import { MatterbridgeBindingServer } from '../src/behaviors/bindingServer.js';
 import { MatterbridgeDoorLockServer } from '../src/behaviors/doorLockServer.js';
-import { closureController, doorLock, irrigationSystem, temperatureSensor } from '../src/matterbridgeDeviceTypes.js';
+import { closureController, doorbell, doorLock, irrigationSystem, temperatureSensor } from '../src/matterbridgeDeviceTypes.js';
 import { MatterbridgeEndpoint } from '../src/matterbridgeEndpoint.js';
 import {
   getApparentElectricalPowerMeasurementClusterServer,
@@ -437,5 +438,13 @@ describe('Options helpers', () => {
     expect(device.behaviors.has(MatterbridgeBindingServer)).toBe(true);
     await addDevice(aggregator, device);
     expect(device.stateOf(DescriptorServer).clientList).toContain(FlowMeasurement.id);
+  });
+
+  test('addRequiredClusterClients maps the Chime client cluster required by the Doorbell device type', async () => {
+    device = new MatterbridgeEndpoint(doorbell, { id: 'DoorbellClusterClients' });
+    device.addRequiredClusterClients();
+    expect(loggerWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('no client behavior found'));
+    await addDevice(aggregator, device);
+    expect(device.stateOf(DescriptorServer).clientList).toContain(Chime.id);
   });
 });


### PR DESCRIPTION
## Summary

Re-lands the Chime device type foundation that was previously part of #577, rebuilt against current `main` per maintainer guidance.

- Add `MatterbridgeChimeServer` behavior (`packages/core/src/behaviors/chimeServer.ts`), extending `ChimeServer`, handling the `playChimeSound` command: resolves the chime ID from the request or falls back to `selectedChime`, forwards the command to the Matterbridge command handler, logs the action, and emits the `chimeStartedPlaying` event.
- Add `MatterbridgeEndpoint.createDefaultChimeClusterServer(...)` helper to create a default Chime cluster server with configurable `installedChimeSounds`, `selectedChime`, and `enabled` state.
- Wire up the `chime` device type in `addClusterServers()` so it is created automatically via `addRequiredClusterServers()`.
- Extend `MatterbridgeEndpointCommandHandler` with the `playChimeSound` command handler type/entry (`Chime.playChimeSound`).
- Export `MatterbridgeChimeServer` from `packages/core/src/behaviors/export.ts`.
- Map the Chime **client** cluster to `ChimeClient` in `getBehaviourTypeFromClusterClientId()`, so endpoints using the `doorbell` device type (which requires it) resolve a working client binding instead of a "no client behavior found" warning.
- Vitest coverage: `createDefaultChimeClusterServer` default-attributes test, Chime device creation/registration/`playChimeSound` invocation on the server node, and the Chime client cluster mapping for the Doorbell device type.
- CHANGELOG entry.

This is the foundation PR; a follow-up PR adds a `Doorbell` single-class device on top of it.

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (scoped to `packages/core`)
- [x] `npm run test -- matterbridgeEndpoint-default.test.ts matterbridgeEndpoint-matterjs.test.ts matterbridgeEndpointHelpers.test.ts` (155 passed)