### PR TITLE
Fix ClosureTag export shadowing and add tagList support to Closure device

### DIFF
--- a/packages/core/src/devices/closure.ts
+++ b/packages/core/src/devices/closure.ts
@@ -28,6 +28,7 @@
 // @matter
 import { ClosureControlServer } from '@matter/node/behaviors/closure-control';
 import { ClosureControl } from '@matter/types/clusters/closure-control';
+import type { Semtag } from '@matter/types/globals';
 import { ThreeLevelAuto } from '@matter/types/globals';
 
 // Matterbridge
@@ -84,6 +85,7 @@ export class MatterbridgeClosureControlServer extends ClosureControlServer.with(
 
 export interface ClosureOptions {
   mainState?: ClosureControl.MainState;
+  tagList?: Semtag[];
 }
 
 /**
@@ -98,7 +100,7 @@ export class Closure extends MatterbridgeEndpoint {
    * @param {ClosureOptions} [options] - Optional initial cluster state values.
    */
   constructor(name: string, serial: string, options: ClosureOptions = {}) {
-    super([closure], { id: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}` });
+    super([closure], { id: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}`, tagList: options.tagList });
 
     this.createDefaultIdentifyClusterServer();
     this.createDefaultBasicInformationClusterServer(name, serial, 0xfff1, 'Matterbridge', 0x8000, 'Matterbridge Closure');

--- a/packages/core/src/matter/export.ts
+++ b/packages/core/src/matter/export.ts
@@ -29,8 +29,6 @@ export { MdnsService, Val } from '@matter/main/protocol';
 // Fix the export of the Common*NamespaceTag to *NamespaceTag
 /** @deprecated Use CommonAreaNamespaceTag instead. */
 export { CommonAreaNamespaceTag as AreaNamespaceTag } from '@matter/main/node';
-/** @deprecated Use CommonClosureTag instead. */
-export { CommonClosureTag as ClosureTag } from '@matter/main/node';
 /** @deprecated Use CommonCompassDirectionTag instead. */
 export { CommonCompassDirectionTag as CompassDirectionTag } from '@matter/main/node';
 /** @deprecated Use CommonCompassLocationTag instead. */


### PR DESCRIPTION
## Summary
- `packages/core/src/matter/export.ts`: removed the `CommonClosureTag as ClosureTag` alias, which was shadowing the real Matter 1.5 closure-domain `ClosureTag` namespace (id `0x44`, with `Covering`/`Window`/`Barrier`/`Cabinet`/`Gate`/`GarageDoor`/`Door`) already provided by `@matter/main`'s star export. `CommonClosureTag` remains available under its own name, so this is not a removal of functionality — just un-shadowing the correct one.
- `packages/core/src/devices/closure.ts`: added an optional `tagList?: Semtag[]` to `ClosureOptions`, forwarded to the `MatterbridgeEndpoint` super() call, so plugin authors can tag a `Closure` endpoint (e.g. as a garage door) without dropping to a raw endpoint:
  ```ts
  new Closure('Garage Door', 'GAR000071', { tagList: [getSemtag(ClosureTag.GarageDoor)] });
  ```

Found and reported in #583 while adding a garage-door example (using the `Closure` single-class device) to `matterbridge-example-dynamic-platform`.

## Test plan
- [x] `npm run build` (tsgo project build) passes
- [x] `oxlint` on the two changed files reports no issues
- [x] `oxfmt --check` on the two changed files passes
- [x] `packages/core/vitest/devices/closure.test.ts` — 8/8 passing, unchanged
- [x] Verified at runtime that `import { ClosureTag } from 'matterbridge/matter'` now resolves to the real namespace (`{ Covering, Window, Barrier, Cabinet, Gate, GarageDoor, Door }`, namespaceId `0x44`) while `CommonClosureTag` still resolves to the deprecated one (`{ Opening, Closing, Stop }`, namespaceId `0x1`)

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)