### PR TITLE
Add addPanel() to Closure device and tagList support to ClosurePanelOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ These classes will run as threads in the next releases:
 - [devcontainer]: Add dedicated `.devcontainer/node` and `.devcontainer/bun` profiles with their own Dockerfile, docker-compose, and create/start scripts.
 - [devices]: Add `tagList` support to the `ClosureOptions` used by the `Closure` device constructor (thanks Ludovic BOUÉ).
 - [closure]: Add `countdownTime`, `mainState`, `currentErrorList`, `overallCurrentState`, `overallTargetState`, and `latchControlModes` support to the `ClosureOptions` used by the `Closure` device constructor.
+- [devices]: Add `addPanel()` to the `Closure` device and `tagList` support to `ClosurePanelOptions` to compose closures with multiple closure panels (e.g. a venetian blind with `ClosurePanelTag.Lift` and `ClosurePanelTag.Tilt` panels).
 
 ### Changed
 

--- a/packages/core/src/devices/closure.ts
+++ b/packages/core/src/devices/closure.ts
@@ -157,7 +157,7 @@ export class Closure extends MatterbridgeEndpoint {
    *
    * @param {string} name - Human-readable name of the panel endpoint.
    * @param {Semtag[]} tagList - The tagList used to disambiguate the panel (e.g. `ClosurePanelTag.Lift`, `ClosurePanelTag.Tilt`).
-   * @param {ClosurePanelOptions} [options] - Optional initial configuration values for the ClosureDimension cluster.
+   * @param {Pick<ClosurePanelOptions, 'resolution' | 'stepValue'>} [options] - Optional initial `resolution`/`stepValue` values for the ClosureDimension cluster.
    * @returns {MatterbridgeEndpoint} The created closure panel endpoint.
    */
   addPanel(name: string, tagList: Semtag[], options: Pick<ClosurePanelOptions, 'resolution' | 'stepValue'> = {}): MatterbridgeEndpoint {

--- a/packages/core/src/devices/closure.ts
+++ b/packages/core/src/devices/closure.ts
@@ -33,9 +33,10 @@ import { ThreeLevelAuto } from '@matter/types/globals';
 
 // Matterbridge
 import { MatterbridgeServer } from '../behaviors/matterbridgeServer.js';
-import { closure } from '../matterbridgeDeviceTypes.js';
+import { closure, closurePanel } from '../matterbridgeDeviceTypes.js';
 import { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
 import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandler.js';
+import { MatterbridgeClosureDimensionServer, type ClosurePanelOptions } from './closurePanel.js';
 
 /**
  * ClosureControl server that forwards MoveTo/Stop commands to the Matterbridge command handler.
@@ -145,5 +146,30 @@ export class Closure extends MatterbridgeEndpoint {
    */
   getMainState(): ClosureControl.MainState | undefined {
     return this.getAttribute(ClosureControlServer, 'mainState');
+  }
+
+  /**
+   * Adds a closure panel as a child endpoint of this closure and configures its ClosureDimension cluster.
+   *
+   * @remarks
+   * Use this to compose a closure out of one or more independently controlled panels, for example a venetian
+   * blind with a `ClosurePanelTag.Lift` panel and a `ClosurePanelTag.Tilt` panel.
+   *
+   * @param {string} name - Human-readable name of the panel endpoint.
+   * @param {Semtag[]} tagList - The tagList used to disambiguate the panel (e.g. `ClosurePanelTag.Lift`, `ClosurePanelTag.Tilt`).
+   * @param {ClosurePanelOptions} [options] - Optional initial configuration values for the ClosureDimension cluster.
+   * @returns {MatterbridgeEndpoint} The created closure panel endpoint.
+   */
+  addPanel(name: string, tagList: Semtag[], options: Pick<ClosurePanelOptions, 'resolution' | 'stepValue'> = {}): MatterbridgeEndpoint {
+    const panel = this.addChildDeviceType(name, closurePanel, { tagList });
+
+    panel.behaviors.require(MatterbridgeClosureDimensionServer, {
+      currentState: null,
+      targetState: null,
+      resolution: options.resolution ?? 1,
+      stepValue: options.stepValue ?? 1,
+    });
+
+    return panel;
   }
 }

--- a/packages/core/src/devices/closurePanel.ts
+++ b/packages/core/src/devices/closurePanel.ts
@@ -28,6 +28,7 @@
 // @matter
 import { ClosureDimensionServer } from '@matter/node/behaviors/closure-dimension';
 import { ClosureDimension } from '@matter/types/clusters/closure-dimension';
+import type { Semtag } from '@matter/types/globals';
 import { ThreeLevelAuto } from '@matter/types/globals';
 
 // Matterbridge
@@ -105,6 +106,7 @@ export class MatterbridgeClosureDimensionServer extends ClosureDimensionServer.w
 export interface ClosurePanelOptions {
   resolution?: number;
   stepValue?: number;
+  tagList?: Semtag[];
 }
 
 /**
@@ -116,10 +118,10 @@ export class ClosurePanel extends MatterbridgeEndpoint {
    *
    * @param {string} name - Human-readable device name.
    * @param {string} serial - Device serial number.
-   * @param {ClosurePanelOptions} [options] - Optional initial configuration values.
+   * @param {ClosurePanelOptions} [options] - Optional initial configuration values, including the tagList used to disambiguate sibling panels (e.g. `ClosurePanelTag.Lift` and `ClosurePanelTag.Tilt`).
    */
   constructor(name: string, serial: string, options: ClosurePanelOptions = {}) {
-    super([closurePanel], { id: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}` });
+    super([closurePanel], { id: `${name.replaceAll(' ', '')}-${serial.replaceAll(' ', '')}`, tagList: options.tagList });
 
     this.createDefaultBasicInformationClusterServer(name, serial, 0xfff1, 'Matterbridge', 0x8000, 'Matterbridge Closure Panel');
 

--- a/packages/core/vitest/devices/closure.test.ts
+++ b/packages/core/vitest/devices/closure.test.ts
@@ -8,7 +8,9 @@ const NAME = 'Closure';
 const MATTER_PORT = 8022;
 const MATTER_CREATE_ONLY = true;
 
+import { ClosureCoveringTag, ClosurePanelTag, ClosureTag } from '@matter/node';
 import { ClosureControl } from '@matter/types/clusters/closure-control';
+import { ClosureDimension } from '@matter/types/clusters/closure-dimension';
 import { Identify } from '@matter/types/clusters/identify';
 import { loggerErrorSpy, loggerFatalSpy, loggerWarnSpy, setupTest } from '@matterbridge/vitest-utils';
 import {
@@ -26,12 +28,14 @@ import { stringify } from 'node-ansi-logger';
 
 import { Closure } from '../../src/devices/closure.js';
 import { closure } from '../../src/matterbridgeDeviceTypes.js';
+import { getSemtag } from '../../src/matterbridgeEndpointHelpers.js';
 
 // Setup the test environment
 await setupTest(NAME, false);
 
 describe('Matterbridge ' + NAME, () => {
   let device: Closure;
+  let venetianBlind: Closure;
 
   beforeAll(async () => {
     // Setup the Matter test environment
@@ -114,6 +118,32 @@ describe('Matterbridge ' + NAME, () => {
       position: ClosureControl.TargetPosition.MoveToFullyClosed,
       latch: false,
     });
+  });
+
+  test('create a closure device with two panels', () => {
+    venetianBlind = new Closure('Venetian Blind Test Device', 'CL654321', {
+      tagList: [getSemtag(ClosureTag.Covering), getSemtag(ClosureCoveringTag.Venetian)],
+    });
+    venetianBlind.addPanel('Lift', [getSemtag(ClosurePanelTag.Lift)]);
+    venetianBlind.addPanel('Tilt', [getSemtag(ClosurePanelTag.Tilt)], { resolution: 2, stepValue: 100 });
+
+    expect(venetianBlind.getChildEndpointByOriginalId('Lift')).toBeDefined();
+    expect(venetianBlind.getChildEndpointByOriginalId('Lift')?.hasClusterServer(ClosureDimension.id)).toBeTruthy();
+    expect(venetianBlind.getChildEndpointByOriginalId('Tilt')).toBeDefined();
+    expect(venetianBlind.getChildEndpointByOriginalId('Tilt')?.getClusterServerOptions(ClosureDimension.id)).toMatchObject({
+      resolution: 2,
+      stepValue: 100,
+    });
+  });
+
+  test('add a closure device with two panels', async () => {
+    expect(await addDevice(server, venetianBlind)).toBeTruthy();
+    expect(venetianBlind.getChildEndpointByOriginalId('Lift')?.getAttribute('Descriptor', 'tagList')).toEqual([
+      { mfgCode: null, namespaceId: ClosurePanelTag.Lift.namespaceId, tag: ClosurePanelTag.Lift.tag },
+    ]);
+    expect(venetianBlind.getChildEndpointByOriginalId('Tilt')?.getAttribute('Descriptor', 'tagList')).toEqual([
+      { mfgCode: null, namespaceId: ClosurePanelTag.Tilt.namespaceId, tag: ClosurePanelTag.Tilt.tag },
+    ]);
   });
 
   test('device forEachAttribute', () => {

--- a/packages/core/vitest/devices/closure.test.ts
+++ b/packages/core/vitest/devices/closure.test.ts
@@ -120,7 +120,7 @@ describe('Matterbridge ' + NAME, () => {
     });
   });
 
-  test('create a closure device with two panels', () => {
+  test('create and add a closure device with two panels', async () => {
     venetianBlind = new Closure('Venetian Blind Test Device', 'CL654321', {
       tagList: [getSemtag(ClosureTag.Covering), getSemtag(ClosureCoveringTag.Venetian)],
     });
@@ -134,9 +134,7 @@ describe('Matterbridge ' + NAME, () => {
       resolution: 2,
       stepValue: 100,
     });
-  });
 
-  test('add a closure device with two panels', async () => {
     expect(await addDevice(server, venetianBlind)).toBeTruthy();
     expect(venetianBlind.getChildEndpointByOriginalId('Lift')?.getAttribute('Descriptor', 'tagList')).toEqual([
       { mfgCode: null, namespaceId: ClosurePanelTag.Lift.namespaceId, tag: ClosurePanelTag.Lift.tag },


### PR DESCRIPTION
## Summary
- Add `Closure.addPanel(name, tagList, options)` to compose a closure out of one or more independently controlled `ClosurePanel` child endpoints.
- Add `tagList` support to `ClosurePanelOptions` so panels can carry semantic tags for disambiguation (e.g. `ClosurePanelTag.Lift`, `ClosurePanelTag.Tilt`).
- Follows the Matter spec's multi-panel closure composition example (e.g. a venetian blind: `Closure` tagged `ClosureTag.Covering` + `ClosureCoveringTag.Venetian`, with `Lift` and `Tilt` panel children).

## Test plan
- [x] `npm run build`
- [x] `npx oxlint --disable-nested-config` on touched files
- [x] `npx oxfmt --check` on touched files
- [x] `npx vitest run packages/core/vitest/devices/closure.test.ts packages/core/vitest/devices/closurePanel.test.ts` (19 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)