### PR TITLE
feat(thermostat): add Thermostat.Feature.MatterScheduleConfiguration support

### DIFF
--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -23,7 +23,9 @@
 
 /* oxlint-disable typescript/no-unsafe-type-assertion */
 
+import { Bytes } from '@matter/general';
 import { ThermostatServer } from '@matter/node/behaviors/thermostat';
+import { StatusResponse } from '@matter/types';
 import { Thermostat } from '@matter/types/clusters/thermostat';
 
 import type { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
@@ -31,13 +33,14 @@ import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandl
 import { MatterbridgeServer } from './matterbridgeServer.js';
 
 /**
- * Thermostat server (cooling/heating/auto/presets) with Matterbridge-specific command handling.
+ * Thermostat server (cooling/heating/auto/presets/schedules) with Matterbridge-specific command handling.
  */
 export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.Cooling,
   Thermostat.Feature.Heating,
   Thermostat.Feature.AutoMode,
   Thermostat.Feature.Presets,
+  Thermostat.Feature.MatterScheduleConfiguration,
 ) {
   /**
    * Initializes thermostat behavior and adjusts command lists to avoid unsupported atomic commands.
@@ -100,5 +103,34 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     device.log.debug(
       `MatterbridgeThermostatServer: setActivePresetRequest completed with activePresetHandle: ${activePresetHandle} occupiedHeatingSetpoint: ${this.state.occupiedHeatingSetpoint} occupiedCoolingSetpoint: ${this.state.occupiedCoolingSetpoint}`,
     );
+  }
+
+  /**
+   * Forwards SetActiveScheduleRequest requests to the Matterbridge command handler and updates the active schedule handle.
+   *
+   * @param {Thermostat.SetActiveScheduleRequest} request - Set-active-schedule request payload.
+   *
+   * @remarks
+   * matter.js does not yet provide a default implementation of this command (the MatterScheduleConfiguration feature
+   * is not implemented by `ThermostatServer` in `@matter/node`), so validation and state handling are done here.
+   */
+  override async setActiveScheduleRequest(request: Thermostat.SetActiveScheduleRequest): Promise<void> {
+    const device = this.endpoint.stateOf(MatterbridgeServer);
+    const scheduleHandle = `0x${Buffer.from(request.scheduleHandle).toString('hex')}`;
+    device.log.info(`Setting schedule to ${scheduleHandle} (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+    await device.commandHandler.executeHandler('Thermostat.setActiveScheduleRequest', {
+      command: 'setActiveScheduleRequest',
+      request,
+      cluster: ThermostatServer.id,
+      attributes: this.state as unknown as ClusterAttributeValues<(typeof Thermostat)['attributes']>,
+      endpoint: this.endpoint as MatterbridgeEndpoint,
+      context: this.context,
+    });
+    const schedule = this.state.schedules.find((s) => s.scheduleHandle !== null && Bytes.areEqual(s.scheduleHandle, request.scheduleHandle));
+    if (schedule === undefined) {
+      throw new StatusResponse.NotFoundError('Requested ScheduleHandle not found');
+    }
+    this.state.activeScheduleHandle = request.scheduleHandle;
+    device.log.debug(`MatterbridgeThermostatServer: setActiveScheduleRequest completed with activeScheduleHandle: ${scheduleHandle}`);
   }
 }

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -130,7 +130,7 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     if (schedule === undefined) {
       throw new StatusResponse.NotFoundError('Requested ScheduleHandle not found');
     }
-    this.state.activeScheduleHandle = request.scheduleHandle;
+    this.state.activeScheduleHandle = Uint8Array.from(request.scheduleHandle);
     device.log.debug(`MatterbridgeThermostatServer: setActiveScheduleRequest completed with activeScheduleHandle: ${scheduleHandle}`);
   }
 }

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3401,7 +3401,11 @@ export class MatterbridgeEndpoint extends Endpoint {
         ...(occupied !== undefined ? { occupancy: { occupied } } : {}),
         ...(occupied !== undefined ? { externallyMeasuredOccupancy: true } : {}),
         // Thermostat.Feature.MatterScheduleConfiguration
-        numberOfSchedules: Math.max(Array.isArray(schedules) ? schedules.length : 0, 10), // This attribute SHALL indicate the maximum number of entries supported by the Schedules attribute.
+        numberOfSchedules: Math.max(
+          Array.isArray(schedules) ? schedules.length : 0,
+          Array.isArray(scheduleTypes) ? Math.max(0, ...scheduleTypes.map((st) => st.numberOfSchedules ?? 0)) : 0,
+          10,
+        ), // This attribute SHALL indicate the maximum number of entries supported by the Schedules attribute, and must be consistent with the per-type capacities advertised in scheduleTypes.
         numberOfScheduleTransitions,
         numberOfScheduleTransitionPerDay,
         activeScheduleHandle: activeScheduleHandle ? Uint8Array.from(activeScheduleHandle) : null,

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3312,6 +3312,120 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
+   * Creates a default thermostat cluster server with features **Heating**, **Cooling**, **AutoMode** and **MatterScheduleConfiguration**.
+   *
+   * - When the occupied parameter is provided (either false or true), the **Occupancy** feature is also added (defaults to undefined).
+   * - When the outdoorTemperature parameter is provided (either null or a number), the outdoorTemperature attribute is also added (defaults to undefined).
+   *
+   * @param {number} [localTemperature] - The local temperature value in degrees Celsius. Defaults to 23°.
+   * @param {number} [occupiedHeatingSetpoint] - The occupied heating setpoint value in degrees Celsius. Defaults to 21°.
+   * @param {number} [occupiedCoolingSetpoint] - The occupied cooling setpoint value in degrees Celsius. Defaults to 25°.
+   * @param {number} [minSetpointDeadBand] - The minimum setpoint dead band value. Defaults to 0°.
+   * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
+   * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
+   * @param {number} [minCoolSetpointLimit] - The minimum cool setpoint limit value. Defaults to 0°.
+   * @param {number} [maxCoolSetpointLimit] - The maximum cool setpoint limit value. Defaults to 50°.
+   * @param {number | undefined} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 19° (it will be ignored if occupied is not provided).
+   * @param {number | undefined} [unoccupiedCoolingSetpoint] - The unoccupied cooling setpoint value in degrees Celsius. Defaults to 27° (it will be ignored if occupied is not provided).
+   * @param {boolean | undefined} [occupied] - The occupancy status. Defaults to undefined (it will be ignored).
+   * @param {number | null | undefined} [outdoorTemperature] - The outdoor temperature value in degrees Celsius. Defaults to undefined (it will be ignored).
+   * @param {Uint8Array | null} [activeScheduleHandle] - The active schedule handle. Defaults to null.
+   * @param {Thermostat.Schedule[]} [schedules] - The list of thermostat schedules. Defaults to empty array.
+   * @param {Thermostat.ScheduleType[]} [scheduleTypes] - The list of thermostat schedule types. Defaults to a predefined set supporting the Auto system mode.
+   * @param {number} [numberOfScheduleTransitions] - The maximum number of transitions per schedule entry. Defaults to 10.
+   * @param {number | null} [numberOfScheduleTransitionPerDay] - The maximum number of transitions per day of the week for each schedule entry. Defaults to null (no limit).
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * matter.js does not yet provide validation logic for the MatterScheduleConfiguration feature (the `schedules` attribute
+   * write validation described in the Matter specification is not enforced by `@matter/node`). Matterbridge only exposes the
+   * attributes and forwards `setActiveScheduleRequest` to the Matterbridge command handler.
+   */
+  createDefaultSchedulesThermostatClusterServer(
+    localTemperature: number = 23,
+    occupiedHeatingSetpoint: number = 21,
+    occupiedCoolingSetpoint: number = 25,
+    minSetpointDeadBand: number = 0,
+    minHeatSetpointLimit: number = 0,
+    maxHeatSetpointLimit: number = 50,
+    minCoolSetpointLimit: number = 0,
+    maxCoolSetpointLimit: number = 50,
+    unoccupiedHeatingSetpoint?: number,
+    unoccupiedCoolingSetpoint?: number,
+    occupied?: boolean,
+    outdoorTemperature?: number | null,
+    activeScheduleHandle: Uint8Array | null = null,
+    schedules: Thermostat.Schedule[] = [],
+    scheduleTypes: Thermostat.ScheduleType[] = [
+      {
+        systemMode: Thermostat.SystemMode.Auto,
+        numberOfSchedules: 10,
+        scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+      },
+    ],
+    numberOfScheduleTransitions: number = 10,
+    numberOfScheduleTransitionPerDay: number | null = null,
+  ): this {
+    this.behaviors.require(
+      MatterbridgeThermostatServer.with(
+        Thermostat.Feature.Heating,
+        Thermostat.Feature.Cooling,
+        Thermostat.Feature.AutoMode,
+        ...(occupied !== undefined ? [Thermostat.Feature.Occupancy] : []),
+        Thermostat.Feature.MatterScheduleConfiguration,
+      ),
+      {
+        localTemperature: localTemperature * 100,
+        externalMeasuredIndoorTemperature: localTemperature * 100,
+        ...(outdoorTemperature !== undefined ? { outdoorTemperature: outdoorTemperature !== null ? outdoorTemperature * 100 : outdoorTemperature } : {}), // Optional nullable attribute
+        systemMode: Thermostat.SystemMode.Auto,
+        controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.CoolingAndHeating,
+        // Thermostat.Feature.Heating
+        occupiedHeatingSetpoint: occupiedHeatingSetpoint * 100,
+        minHeatSetpointLimit: minHeatSetpointLimit * 100,
+        maxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+        absMinHeatSetpointLimit: minHeatSetpointLimit * 100,
+        absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+        // Thermostat.Feature.Cooling
+        occupiedCoolingSetpoint: occupiedCoolingSetpoint * 100,
+        minCoolSetpointLimit: minCoolSetpointLimit * 100,
+        maxCoolSetpointLimit: maxCoolSetpointLimit * 100,
+        absMinCoolSetpointLimit: minCoolSetpointLimit * 100,
+        absMaxCoolSetpointLimit: maxCoolSetpointLimit * 100,
+        // Thermostat.Feature.AutoMode
+        minSetpointDeadBand: minSetpointDeadBand * 10,
+        thermostatRunningMode: Thermostat.ThermostatRunningMode.Off,
+        // Thermostat.Feature.Occupancy
+        ...(occupied !== undefined ? { unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint !== undefined ? unoccupiedHeatingSetpoint * 100 : 1900 } : {}),
+        ...(occupied !== undefined ? { unoccupiedCoolingSetpoint: unoccupiedCoolingSetpoint !== undefined ? unoccupiedCoolingSetpoint * 100 : 2700 } : {}),
+        ...(occupied !== undefined ? { occupancy: { occupied } } : {}),
+        ...(occupied !== undefined ? { externallyMeasuredOccupancy: true } : {}),
+        // Thermostat.Feature.MatterScheduleConfiguration
+        numberOfSchedules: Math.max(Array.isArray(schedules) ? schedules.length : 0, 10), // This attribute SHALL indicate the maximum number of entries supported by the Schedules attribute.
+        numberOfScheduleTransitions,
+        numberOfScheduleTransitionPerDay,
+        activeScheduleHandle: activeScheduleHandle ? Uint8Array.from(activeScheduleHandle) : null,
+        // Ensure scheduleHandle and presetHandle are proper Uint8Array by creating new instances
+        schedules: (schedules ?? []).map((s) => ({
+          scheduleHandle: s.scheduleHandle ? Uint8Array.from(s.scheduleHandle) : null,
+          systemMode: s.systemMode,
+          name: s.name,
+          presetHandle: s.presetHandle ? Uint8Array.from(s.presetHandle) : undefined,
+          transitions: s.transitions ?? [],
+          builtIn: s.builtIn ?? true,
+        })),
+        scheduleTypes: (scheduleTypes ?? []).map((st) => ({
+          // oxlint-disable-next-line typescript/no-misused-spread
+          ...st,
+          numberOfSchedules: st.numberOfSchedules ?? 0,
+          scheduleTypeFeatures: st.scheduleTypeFeatures ?? { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+        })),
+      },
+    );
+    return this;
+  }
+
+  /**
    * Creates a default cooling thermostat cluster server with feature **Cooling**.
    *
    * - When the occupied parameter is provided (either false or true), the **Occupancy** feature is also added (defaults to undefined).

--- a/packages/core/src/matterbridgeEndpointCommandHandler.ts
+++ b/packages/core/src/matterbridgeEndpointCommandHandler.ts
@@ -466,6 +466,7 @@ export type CommandHandlerDataMap = {
   // Thermostat
   'setpointRaiseLower': CommandHandlerData<'Thermostat.setpointRaiseLower'>;
   'setActivePresetRequest': CommandHandlerData<'Thermostat.setActivePresetRequest'>;
+  'setActiveScheduleRequest': CommandHandlerData<'Thermostat.setActiveScheduleRequest'>;
   'Thermostat.setpointRaiseLower': {
     command: 'setpointRaiseLower';
     request: Thermostat.SetpointRaiseLowerRequest;
@@ -476,6 +477,13 @@ export type CommandHandlerDataMap = {
   'Thermostat.setActivePresetRequest': {
     command: 'setActivePresetRequest';
     request: Thermostat.SetActivePresetRequest;
+    cluster: 'thermostat';
+    attributes: ClusterAttributeValues<(typeof Thermostat)['attributes']>;
+    endpoint: MatterbridgeEndpoint;
+  };
+  'Thermostat.setActiveScheduleRequest': {
+    command: 'setActiveScheduleRequest';
+    request: Thermostat.SetActiveScheduleRequest;
     cluster: 'thermostat';
     attributes: ClusterAttributeValues<(typeof Thermostat)['attributes']>;
     endpoint: MatterbridgeEndpoint;

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1011,6 +1011,10 @@ describe('Server clusters and behaviors', () => {
     );
     expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([1]));
 
+    // The stored activeScheduleHandle must be a defensive copy, not a reference to the request payload.
+    secondScheduleRequest.scheduleHandle[0] = 0xff;
+    expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([1]));
+
     await expect(thermostatSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', invalidScheduleRequest)).rejects.toThrow('Requested ScheduleHandle not found');
     expect(scheduleCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSchedule, request: invalidScheduleRequest });
     expect(scheduleCalls).toHaveLength(2);

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -97,6 +97,7 @@ describe('Server clusters and behaviors', () => {
   let vent: MatterbridgeEndpoint;
   let thermo: MatterbridgeEndpoint;
   let thermostatPreset: MatterbridgeEndpoint;
+  let thermostatSchedule: MatterbridgeEndpoint;
   let valve: MatterbridgeEndpoint;
   let smoke: MatterbridgeEndpoint;
   let contact: MatterbridgeEndpoint;
@@ -133,6 +134,55 @@ describe('Server clusters and behaviors', () => {
       Uint8Array.from([0]), // activePresetHandle: Uint8Array | null
       thermostatPresets, // presetsList: Thermostat.Preset[]
       thermostatPresetTypes, // presetTypesList: Thermostat.PresetType[]
+    );
+    endpoint.addRequiredClusterServers();
+    return endpoint;
+  }
+
+  const thermostatScheduleTypes: Thermostat.ScheduleType[] = [
+    {
+      systemMode: Thermostat.SystemMode.Auto,
+      numberOfSchedules: 2,
+      scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+    },
+  ];
+  const thermostatSchedules: Thermostat.Schedule[] = [
+    {
+      scheduleHandle: Uint8Array.from([0]),
+      systemMode: Thermostat.SystemMode.Auto,
+      name: 'Weekdays',
+      transitions: [
+        { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 420, coolingSetpoint: 2500, heatingSetpoint: 2100 },
+      ],
+      builtIn: null,
+    },
+    {
+      scheduleHandle: Uint8Array.from([1]),
+      systemMode: Thermostat.SystemMode.Auto,
+      name: 'Weekend',
+      transitions: [{ dayOfWeek: { saturday: true, sunday: true }, transitionTime: 480, coolingSetpoint: 2700, heatingSetpoint: 1900 }],
+      builtIn: null,
+    },
+  ];
+
+  function createScheduleThermostatEndpoint(id: string): MatterbridgeEndpoint {
+    const endpoint = new MatterbridgeEndpoint(thermostat, { id });
+    endpoint.createDefaultSchedulesThermostatClusterServer(
+      23,
+      21,
+      25,
+      2,
+      0,
+      48,
+      2,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Uint8Array.from([0]), // activeScheduleHandle: Uint8Array | null
+      thermostatSchedules, // schedules: Thermostat.Schedule[]
+      thermostatScheduleTypes, // scheduleTypes: Thermostat.ScheduleType[]
     );
     endpoint.addRequiredClusterServers();
     return endpoint;
@@ -936,6 +986,36 @@ describe('Server clusters and behaviors', () => {
     expect(presetCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatPreset, request: invalidPresetRequest });
     expect(presetCalls).toHaveLength(4);
     expectPresetThermostatAttributes(null, 1900, 2700);
+  });
+
+  test('ScheduleThermostat server', async () => {
+    thermostatSchedule = createScheduleThermostatEndpoint('thermostatScheduleBehavior');
+    expect(await addDevice(aggregator, thermostatSchedule)).toBeTruthy();
+
+    const formatScheduleHandleForLog = (scheduleHandle: Uint8Array) => `0x${Buffer.from(scheduleHandle).toString('hex')}`;
+    const secondScheduleRequest = { scheduleHandle: Uint8Array.from([1]) };
+    const invalidScheduleRequest = { scheduleHandle: Uint8Array.from([9]) };
+    const scheduleCalls: Array<{ cluster: string; endpoint: MatterbridgeEndpoint; request: object }> = [];
+
+    thermostatSchedule.addCommandHandler('setActiveScheduleRequest', (data) => {
+      scheduleCalls.push({ cluster: data.cluster, endpoint: data.endpoint, request: data.request });
+    });
+
+    expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([0]));
+
+    await thermostatSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', secondScheduleRequest);
+    expect(scheduleCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSchedule, request: secondScheduleRequest });
+    expect(loggerLogSpy).toHaveBeenCalledWith(
+      LogLevel.INFO,
+      `Setting schedule to ${formatScheduleHandleForLog(secondScheduleRequest.scheduleHandle)} (endpoint ${thermostatSchedule.id}.${thermostatSchedule.number})`,
+    );
+    expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([1]));
+
+    await expect(thermostatSchedule.invokeBehaviorCommand('Thermostat', 'setActiveScheduleRequest', invalidScheduleRequest)).rejects.toThrow('Requested ScheduleHandle not found');
+    expect(scheduleCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSchedule, request: invalidScheduleRequest });
+    expect(scheduleCalls).toHaveLength(2);
+    // The active schedule handle must not change when the requested schedule handle is invalid.
+    expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([1]));
   });
 
   test('ValveConfigurationAndControl server', async () => {

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -1455,6 +1455,167 @@ describe('Matterbridge ' + NAME, () => {
     // (matterbridge.frontend as any).getClusterTextFromDevice(device);
   });
 
+  test('createDefaultSchedulesThermostatClusterServer defaults', async () => {
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSchedulesDefault' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultSchedulesThermostatClusterServer();
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+    expect(device.hasAttributeServer(Thermostat.id, 'localTemperature')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'outdoorTemperature')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'systemMode')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupiedHeatingSetpoint')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupiedCoolingSetpoint')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'unoccupiedHeatingSetpoint')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'unoccupiedCoolingSetpoint')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupancy')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'numberOfSchedules')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'numberOfScheduleTransitions')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'numberOfScheduleTransitionPerDay')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'activeScheduleHandle')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'schedules')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'scheduleTypes')).toBe(true);
+    expect(featuresFor(device, 'Thermostat')).toEqual({
+      autoMode: true,
+      cooling: true,
+      events: false,
+      heating: true,
+      localTemperatureNotExposed: false,
+      matterScheduleConfiguration: true,
+      occupancy: false,
+      presets: false,
+      setback: false,
+      thermostatSuggestions: false,
+    });
+
+    await addDevice(aggregator, device);
+    await flushAsync();
+    expect(device.getAttribute(Thermostat.id, 'systemMode')).toBe(Thermostat.SystemMode.Auto);
+    expect(device.getAttribute(Thermostat.id, 'numberOfSchedules')).toBe(10);
+    expect(device.getAttribute(Thermostat.id, 'numberOfScheduleTransitions')).toBe(10);
+    expect(device.getAttribute(Thermostat.id, 'numberOfScheduleTransitionPerDay')).toBeNull();
+    const retrievedSchedules = device.getAttribute(Thermostat.id, 'schedules');
+    expect(retrievedSchedules).toHaveLength(0);
+    const retrievedScheduleTypes = device.getAttribute(Thermostat.id, 'scheduleTypes');
+    expect(retrievedScheduleTypes).toHaveLength(1);
+    expect(device.getCluster(Thermostat)).toMatchObject({
+      absMinHeatSetpointLimit: 0,
+      absMaxHeatSetpointLimit: 5000,
+      absMinCoolSetpointLimit: 0,
+      absMaxCoolSetpointLimit: 5000,
+      occupiedCoolingSetpoint: 2500,
+      occupiedHeatingSetpoint: 2100,
+      minHeatSetpointLimit: 0,
+      maxHeatSetpointLimit: 5000,
+      minCoolSetpointLimit: 0,
+      maxCoolSetpointLimit: 5000,
+      minSetpointDeadBand: 0,
+      numberOfSchedules: 10,
+      numberOfScheduleTransitions: 10,
+      numberOfScheduleTransitionPerDay: null,
+      activeScheduleHandle: null,
+      schedules: [],
+      scheduleTypes: [
+        {
+          systemMode: Thermostat.SystemMode.Auto,
+          numberOfSchedules: 10,
+          scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+        },
+      ],
+    });
+  });
+
+  test('createDefaultSchedulesThermostatClusterServer', async () => {
+    const scheduleTypes: Thermostat.ScheduleType[] = [
+      {
+        systemMode: Thermostat.SystemMode.Auto,
+        numberOfSchedules: 2,
+        scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+      },
+    ];
+    const schedulesList: Thermostat.Schedule[] = [
+      {
+        scheduleHandle: Uint8Array.from([0]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekdays',
+        transitions: [
+          { dayOfWeek: { monday: true, tuesday: true, wednesday: true, thursday: true, friday: true }, transitionTime: 420, coolingSetpoint: 2500, heatingSetpoint: 2100 },
+        ],
+        builtIn: null,
+      },
+      {
+        scheduleHandle: Uint8Array.from([1]),
+        systemMode: Thermostat.SystemMode.Auto,
+        name: 'Weekend',
+        transitions: [{ dayOfWeek: { saturday: true, sunday: true }, transitionTime: 480, coolingSetpoint: 2700, heatingSetpoint: 1900 }],
+        builtIn: null,
+      },
+    ];
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSchedules' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultSchedulesThermostatClusterServer(
+      23,
+      21,
+      25,
+      2,
+      0,
+      48,
+      2,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Uint8Array.from([0]),
+      schedulesList,
+      scheduleTypes,
+      5,
+      3,
+    );
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+    expect(device.hasAttributeServer(Thermostat.id, 'numberOfSchedules')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'activeScheduleHandle')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'schedules')).toBe(true);
+    expect(featuresFor(device, 'Thermostat')).toEqual({
+      autoMode: true,
+      cooling: true,
+      events: false,
+      heating: true,
+      localTemperatureNotExposed: false,
+      matterScheduleConfiguration: true,
+      occupancy: false,
+      presets: false,
+      setback: false,
+      thermostatSuggestions: false,
+    });
+
+    await addDevice(aggregator, device);
+    expect(device.getAttribute(Thermostat.id, 'numberOfSchedules')).toBe(10);
+    expect(device.getAttribute(Thermostat.id, 'numberOfScheduleTransitions')).toBe(5);
+    expect(device.getAttribute(Thermostat.id, 'numberOfScheduleTransitionPerDay')).toBe(3);
+    const retrievedSchedules = device.getAttribute(Thermostat.id, 'schedules');
+    expect(retrievedSchedules).toHaveLength(2);
+    expect(JSON.stringify(Object.values(retrievedSchedules[0].scheduleHandle))).toBe(JSON.stringify([0]));
+    expect(retrievedSchedules[0].name).toBe('Weekdays');
+    expect(retrievedSchedules[0].builtIn).toBe(true);
+    expect(JSON.stringify(Object.values(retrievedSchedules[1].scheduleHandle))).toBe(JSON.stringify([1]));
+    expect(retrievedSchedules[1].name).toBe('Weekend');
+    expect(device.getCluster(Thermostat)).toMatchObject({
+      activeScheduleHandle: Uint8Array.from([0]),
+      numberOfSchedules: 10,
+      numberOfScheduleTransitions: 5,
+      numberOfScheduleTransitionPerDay: 3,
+      scheduleTypes: [
+        {
+          systemMode: Thermostat.SystemMode.Auto,
+          numberOfSchedules: 2,
+          scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+        },
+      ],
+    });
+  });
+
   test('createDefaultFanControlClusterServer', async () => {
     const device = new MatterbridgeEndpoint(fan, { id: 'Fan' });
     expect(device).toBeDefined();

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -1616,6 +1616,24 @@ describe('Matterbridge ' + NAME, () => {
     });
   });
 
+  test('createDefaultSchedulesThermostatClusterServer numberOfSchedules reflects scheduleTypes capacity', async () => {
+    const scheduleTypes: Thermostat.ScheduleType[] = [
+      {
+        systemMode: Thermostat.SystemMode.Auto,
+        numberOfSchedules: 20,
+        scheduleTypeFeatures: { supportsSetpoints: true, supportsNames: true, supportsPresets: false, supportsOff: false },
+      },
+    ];
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSchedulesCapacity' });
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultSchedulesThermostatClusterServer(23, 21, 25, 2, 0, 48, 2, 50, undefined, undefined, undefined, undefined, null, [], scheduleTypes);
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+
+    await addDevice(aggregator, device);
+    // numberOfSchedules must not report less than the capacity advertised in scheduleTypes.
+    expect(device.getAttribute(Thermostat.id, 'numberOfSchedules')).toBe(20);
+  });
+
   test('createDefaultFanControlClusterServer', async () => {
     const device = new MatterbridgeEndpoint(fan, { id: 'Fan' });
     expect(device).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds the **Schedules** feature (`Thermostat.Feature.MatterScheduleConfiguration`, MSSCH) to
  `MatterbridgeThermostatServer`, mirroring the existing Presets support: default attributes
  (`scheduleTypes`, `schedules`, `activeScheduleHandle`, `numberOfSchedules`,
  `numberOfScheduleTransitions`, `numberOfScheduleTransitionPerDay`) via a new
  `createDefaultSchedulesThermostatClusterServer()` helper.
- Adds a `setActiveScheduleRequest` command override that looks up the requested `ScheduleHandle`,
  updates `activeScheduleHandle`, and forwards to the Matterbridge command handler — `matter.js`'s  own `ThermostatServer` does not implement this command or validate the `schedules` attribute for this feature yet.

Closes Luligu/matterbridge#414

## Test plan

- [x] `packages/core` unit tests (`vitest/behaviors/matterbridgeServer.test.ts`,
      `vitest/matterbridgeEndpoint-default.test.ts`)
- [x] Local end-to-end validation with `chip-tool` against a running Matterbridge instance (see log below)

<details>
<summary>chip-tool end-to-end test log (MSSCH)</summary>

```
MSSCH (Thermostat.Feature.MatterScheduleConfiguration) — local chip-tool validation
=====================================================================================

Setup
-----
- matterbridge running locally (packages/core built from this branch), matterbridge-example-dynamic-platform
  loaded with a temporary test device "Thermostat (AutoModeSchedules)" built with the new
  createDefaultSchedulesThermostatClusterServer() helper, 2 schedules ("Weekdays", "Weekend"),
  Auto system mode, 10 max schedules / 10 transitions per schedule.
- chip-tool (snap, local) commissioned as a new controller/fabric on the existing Matterbridge
  aggregator node via the manual pairing code, node id 100 (0x64).
- Device endpoint for the test thermostat: 14.

1) Commissioning
-----------------
$ chip-tool pairing code 100 30313456657
...
[CTL] Commissioning complete for node ID 0x0000000000000064: success
[TOO] Device commissioning completed with success

2) Read ScheduleTypes
----------------------
$ chip-tool thermostat read schedule-types 100 14
  ScheduleTypes: 1 entries
    [1]: {
      SystemMode: 1            # Auto
      NumberOfSchedules: 10
      ScheduleTypeFeatures: 6  # SupportsSetpoints | SupportsNames
     }

3) Read Schedules
-------------------
$ chip-tool thermostat read schedules 100 14
  Schedules: 2 entries
    [1]: {
      ScheduleHandle: 00
      SystemMode: 1
      Name: Weekdays
      Transitions: 2 entries
        [1]: { DayOfWeek: 62, TransitionTime: 360 }   # Mon-Fri, 06:00
        [2]: { DayOfWeek: 62, TransitionTime: 1320 }  # Mon-Fri, 22:00
      BuiltIn: TRUE
     }
    [2]: {
      ScheduleHandle: 01
      SystemMode: 1
      Name: Weekend
      Transitions: 2 entries
        [1]: { DayOfWeek: 65, TransitionTime: 480 }   # Sat+Sun, 08:00
        [2]: { DayOfWeek: 65, TransitionTime: 1380 }  # Sat+Sun, 23:00
      BuiltIn: TRUE
     }

4) Read ActiveScheduleHandle (initial state)
----------------------------------------------
$ chip-tool thermostat read active-schedule-handle 100 14
  ActiveScheduleHandle: null

5) SetActiveScheduleRequest with a valid handle
--------------------------------------------------
$ chip-tool thermostat set-active-schedule-request hex:00 100 14
  status = 0x00 (SUCCESS)

$ chip-tool thermostat read active-schedule-handle 100 14
  ActiveScheduleHandle: 00

Matterbridge-side log:
[Thermostat (AutoModeSchedules)] Setting schedule to 0x00 (endpoint Thermostat(AutoModeSchedules).14)
[Thermostat (AutoModeSchedules)] Command setActiveScheduleRequest called with scheduleHandle: 0x00
[Thermostat (AutoModeSchedules)] Subscribe activeScheduleHandle called with: 0x00 (old value: null)

6) SetActiveScheduleRequest with an unknown handle (expected NOT_FOUND)
----------------------------------------------------------------------
$ chip-tool thermostat set-active-schedule-request hex:ff 100 14
  status = 0x8b (NOT_FOUND)
  [TOO] Error: IM Error 0x0000058B: General error: 0x8b (NOT_FOUND)

7) Switch to the second schedule
-----------------------------------
$ chip-tool thermostat set-active-schedule-request hex:01 100 14
  status = 0x00 (SUCCESS)

$ chip-tool thermostat read active-schedule-handle 100 14
  ActiveScheduleHandle: 01

Matterbridge-side log:
[Thermostat (AutoModeSchedules)] Subscribe activeScheduleHandle called with: 0x01 (old value: 0x00)

Result
------
All checks pass:
- scheduleTypes / schedules / numberOfSchedules / numberOfScheduleTransitions are exposed correctly.
- activeScheduleHandle starts null.
- setActiveScheduleRequest with a known ScheduleHandle succeeds, updates activeScheduleHandle, and fires
  the attribute subscription with correct old/new values.
- setActiveScheduleRequest with an unknown ScheduleHandle is rejected with NOT_FOUND (0x8b) per spec
  §4.3.12.2, and does not corrupt the existing activeScheduleHandle.
- Switching between two valid schedules works repeatedly.
```

</details>

