### PR TITLE
fix(thermostat): numberOfPresets must reflect presetTypes capacity

### DIFF
--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3292,7 +3292,11 @@ export class MatterbridgeEndpoint extends Endpoint {
         ...(occupied !== undefined ? { occupancy: { occupied } } : {}),
         ...(occupied !== undefined ? { externallyMeasuredOccupancy: true } : {}),
         // Thermostat.Feature.Presets
-        numberOfPresets: Math.max(Array.isArray(presets) ? presets.length : 0, 10), // This attribute SHALL indicate the maximum number of entries supported by the Presets attribute.
+        numberOfPresets: Math.max(
+          Array.isArray(presets) ? presets.length : 0,
+          Array.isArray(presetTypes) ? Math.max(0, ...presetTypes.map((pt) => pt.numberOfPresets ?? 0)) : 0,
+          10,
+        ), // This attribute SHALL indicate the maximum number of entries supported by the Presets attribute, and must be consistent with the per-type capacities advertised in presetTypes.
         activePresetHandle: activePresetHandle ? Uint8Array.from([activePresetHandle]) : null,
         // Ensure presetHandle is a proper Uint8Array by creating a new instance
         presets: (presets ?? []).map((p) => ({

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -1091,6 +1091,20 @@ describe('Matterbridge ' + NAME, () => {
     // (matterbridge.frontend as any).getClusterTextFromDevice(device);
   });
 
+  test('createDefaultPresetsThermostatClusterServer numberOfPresets reflects presetTypes capacity', async () => {
+    const presetTypes: Thermostat.PresetType[] = [
+      { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 20, presetTypeFeatures: { automatic: false, supportsNames: true } },
+    ];
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoPresetsCapacity' });
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultPresetsThermostatClusterServer(23, 21, 25, 2, 0, 48, 2, 50, undefined, undefined, undefined, undefined, undefined, [], presetTypes);
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+
+    await addDevice(aggregator, device);
+    // numberOfPresets must not report less than the capacity advertised in presetTypes.
+    expect(device.getAttribute(Thermostat.id, 'numberOfPresets')).toBe(20);
+  });
+
   test('createDefaultPresetsThermostatClusterServer with occupancy', async () => {
     const presetTypes: Thermostat.PresetType[] = [
       { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },


### PR DESCRIPTION
## Summary

- `createDefaultPresetsThermostatClusterServer()` derived `numberOfPresets` only from
  the `presets` array length and a hardcoded floor of 10, ignoring the per-type capacity
  advertised in `presetTypes`. If a caller passes `presetTypes` advertising a higher
  `numberOfSchedules`-style capacity than 10, the cluster reported a smaller
  `numberOfPresets` than its `presetTypes` implied — inconsistent capability reporting.
- Same class of issue as the `numberOfSchedules` fix requested by Copilot review on
  [#588](https://github.com/Luligu/matterbridge/pull/588), just on the (already merged)
  Presets helper instead of the new Schedules helper.
- Fix: `numberOfPresets` is now `Math.max(presets.length, max(presetTypes[].numberOfPresets), 10)`.

## Test plan

- [x] Added a regression test asserting `numberOfPresets` reflects a `presetTypes` capacity above 10.
- [x] `packages/core` unit tests (`vitest matterbridgeEndpoint-default.test.ts`) pass.
