### PR TITLE
feat(thermostat): add Thermostat.Feature.ThermostatSuggestions support

### DIFF
--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -32,11 +32,6 @@ import type { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
 import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandler.js';
 import { MatterbridgeServer } from './matterbridgeServer.js';
 
-/** Command id of the AtomicRequest command (Matter core spec § Atomic Write), not implemented by Matterbridge. */
-const ATOMIC_REQUEST_COMMAND_ID = 0xfe;
-/** Command id of the AtomicResponse command (Matter core spec § Atomic Write), not implemented by Matterbridge. */
-const ATOMIC_RESPONSE_COMMAND_ID = 0xfd;
-
 /**
  * Thermostat server (cooling/heating/auto/presets/schedules/suggestions) with Matterbridge-specific command handling.
  */
@@ -48,30 +43,6 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.MatterScheduleConfiguration,
   Thermostat.Feature.ThermostatSuggestions,
 ) {
-  /**
-   * Initializes thermostat behavior and removes the unsupported AtomicRequest/AtomicResponse commands from the
-   * command lists computed for the enabled features, instead of hard-coding the whole list.
-   */
-  override async initialize(): Promise<void> {
-    await super.initialize();
-
-    this.endpoint.construction.onSuccess(async () => {
-      const device = this.endpoint.stateOf(MatterbridgeServer);
-      device.log.debug(`Removing atomic commands (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
-      // because acceptedCommandList and generatedCommandList are not typed in the cluster state
-      const { acceptedCommandList, generatedCommandList } = this.state as unknown as { acceptedCommandList: unknown; generatedCommandList: unknown };
-      if (!Array.isArray(acceptedCommandList) || !Array.isArray(generatedCommandList)) {
-        device.log.debug(`Skipping removal of atomic commands: command lists not available (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
-        return;
-      }
-      // @ts-expect-error because acceptedCommandList and generatedCommandList are not typed in the cluster state
-      await this.endpoint.setStateOf(ThermostatServer, {
-        acceptedCommandList: (acceptedCommandList as number[]).filter((id) => id !== ATOMIC_REQUEST_COMMAND_ID),
-        generatedCommandList: (generatedCommandList as number[]).filter((id) => id !== ATOMIC_RESPONSE_COMMAND_ID),
-      });
-    });
-  }
-
   /**
    * Forwards SetpointRaiseLower requests to the Matterbridge command handler and updates occupied setpoints.
    *

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -58,13 +58,13 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     this.endpoint.construction.onSuccess(async () => {
       const device = this.endpoint.stateOf(MatterbridgeServer);
       device.log.debug(`Removing atomic commands (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
-      // cause acceptedCommandList and generatedCommandList are not typed in the cluster state
+      // because acceptedCommandList and generatedCommandList are not typed in the cluster state
       const { acceptedCommandList, generatedCommandList } = this.state as unknown as { acceptedCommandList: unknown; generatedCommandList: unknown };
       if (!Array.isArray(acceptedCommandList) || !Array.isArray(generatedCommandList)) {
         device.log.debug(`Skipping removal of atomic commands: command lists not available (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
         return;
       }
-      // @ts-expect-error cause acceptedCommandList and generatedCommandList are not typed in the cluster state
+      // @ts-expect-error because acceptedCommandList and generatedCommandList are not typed in the cluster state
       await this.endpoint.setStateOf(ThermostatServer, {
         acceptedCommandList: (acceptedCommandList as number[]).filter((id) => id !== ATOMIC_REQUEST_COMMAND_ID),
         generatedCommandList: (generatedCommandList as number[]).filter((id) => id !== ATOMIC_RESPONSE_COMMAND_ID),

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -59,11 +59,15 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
       const device = this.endpoint.stateOf(MatterbridgeServer);
       device.log.debug(`Removing atomic commands (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
       // cause acceptedCommandList and generatedCommandList are not typed in the cluster state
-      const { acceptedCommandList, generatedCommandList } = this.state as unknown as { acceptedCommandList: number[]; generatedCommandList: number[] };
+      const { acceptedCommandList, generatedCommandList } = this.state as unknown as { acceptedCommandList: unknown; generatedCommandList: unknown };
+      if (!Array.isArray(acceptedCommandList) || !Array.isArray(generatedCommandList)) {
+        device.log.debug(`Skipping removal of atomic commands: command lists not available (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+        return;
+      }
       // @ts-expect-error cause acceptedCommandList and generatedCommandList are not typed in the cluster state
       await this.endpoint.setStateOf(ThermostatServer, {
-        acceptedCommandList: acceptedCommandList.filter((id) => id !== ATOMIC_REQUEST_COMMAND_ID),
-        generatedCommandList: generatedCommandList.filter((id) => id !== ATOMIC_RESPONSE_COMMAND_ID),
+        acceptedCommandList: (acceptedCommandList as number[]).filter((id) => id !== ATOMIC_REQUEST_COMMAND_ID),
+        generatedCommandList: (generatedCommandList as number[]).filter((id) => id !== ATOMIC_RESPONSE_COMMAND_ID),
       });
     });
   }

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -33,7 +33,7 @@ import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandl
 import { MatterbridgeServer } from './matterbridgeServer.js';
 
 /**
- * Thermostat server (cooling/heating/auto/presets/schedules) with Matterbridge-specific command handling.
+ * Thermostat server (cooling/heating/auto/presets/schedules/suggestions) with Matterbridge-specific command handling.
  */
 export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.Cooling,
@@ -41,6 +41,7 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.AutoMode,
   Thermostat.Feature.Presets,
   Thermostat.Feature.MatterScheduleConfiguration,
+  Thermostat.Feature.ThermostatSuggestions,
 ) {
   /**
    * Forwards SetpointRaiseLower requests to the Matterbridge command handler and updates occupied setpoints.
@@ -115,5 +116,79 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     }
     this.state.activeScheduleHandle = Uint8Array.from(request.scheduleHandle);
     device.log.debug(`MatterbridgeThermostatServer: setActiveScheduleRequest completed with activeScheduleHandle: ${scheduleHandle}`);
+  }
+
+  /**
+   * Forwards AddThermostatSuggestion requests to the Matterbridge command handler and appends the new suggestion.
+   *
+   * @param {Thermostat.AddThermostatSuggestionRequest} request - Add-thermostat-suggestion request payload.
+   * @returns {Promise<Thermostat.AddThermostatSuggestionResponse>} The generated UniqueID of the added suggestion.
+   *
+   * @remarks
+   * matter.js does not yet provide a default implementation of this command (the ThermostatSuggestions feature
+   * is not implemented by `ThermostatServer` in `@matter/node`), so validation and list bookkeeping are done here.
+   */
+  override async addThermostatSuggestion(request: Thermostat.AddThermostatSuggestionRequest): Promise<Thermostat.AddThermostatSuggestionResponse> {
+    const device = this.endpoint.stateOf(MatterbridgeServer);
+    const presetHandle = `0x${Buffer.from(request.presetHandle).toString('hex')}`;
+    device.log.info(`Adding thermostat suggestion for preset ${presetHandle} (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+    await device.commandHandler.executeHandler('Thermostat.addThermostatSuggestion', {
+      command: 'addThermostatSuggestion',
+      request,
+      cluster: ThermostatServer.id,
+      attributes: this.state as unknown as ClusterAttributeValues<(typeof Thermostat)['attributes']>,
+      endpoint: this.endpoint as MatterbridgeEndpoint,
+      context: this.context,
+    });
+    if (this.state.presets.find((p) => p.presetHandle !== null && Bytes.areEqual(p.presetHandle, request.presetHandle)) === undefined) {
+      throw new StatusResponse.NotFoundError('Requested PresetHandle not found');
+    }
+    if (this.state.thermostatSuggestions.length >= this.state.maxThermostatSuggestions) {
+      throw new StatusResponse.ResourceExhaustedError('Maximum number of thermostat suggestions reached');
+    }
+    const usedUniqueIds = new Set(this.state.thermostatSuggestions.map((s) => s.uniqueId));
+    let uniqueId = 0;
+    while (usedUniqueIds.has(uniqueId)) uniqueId++;
+    const effectiveTime = request.effectiveTime ?? Math.floor(Date.now() / 1000);
+    const suggestion: Thermostat.ThermostatSuggestion = {
+      uniqueId,
+      presetHandle: Uint8Array.from(request.presetHandle),
+      effectiveTime,
+      expirationTime: effectiveTime + request.expirationInMinutes * 60,
+    };
+    this.state.thermostatSuggestions = [...this.state.thermostatSuggestions, suggestion];
+    device.log.debug(`MatterbridgeThermostatServer: addThermostatSuggestion completed with uniqueId: ${uniqueId}`);
+    return { uniqueId };
+  }
+
+  /**
+   * Forwards RemoveThermostatSuggestion requests to the Matterbridge command handler and removes the suggestion.
+   *
+   * @param {Thermostat.RemoveThermostatSuggestionRequest} request - Remove-thermostat-suggestion request payload.
+   *
+   * @remarks
+   * matter.js does not yet provide a default implementation of this command (the ThermostatSuggestions feature
+   * is not implemented by `ThermostatServer` in `@matter/node`), so validation and list bookkeeping are done here.
+   */
+  override async removeThermostatSuggestion(request: Thermostat.RemoveThermostatSuggestionRequest): Promise<void> {
+    const device = this.endpoint.stateOf(MatterbridgeServer);
+    device.log.info(`Removing thermostat suggestion ${request.uniqueId} (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+    await device.commandHandler.executeHandler('Thermostat.removeThermostatSuggestion', {
+      command: 'removeThermostatSuggestion',
+      request,
+      cluster: ThermostatServer.id,
+      attributes: this.state as unknown as ClusterAttributeValues<(typeof Thermostat)['attributes']>,
+      endpoint: this.endpoint as MatterbridgeEndpoint,
+      context: this.context,
+    });
+    const suggestion = this.state.thermostatSuggestions.find((s) => s.uniqueId === request.uniqueId);
+    if (suggestion === undefined) {
+      throw new StatusResponse.NotFoundError('Requested UniqueID not found');
+    }
+    this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => s.uniqueId !== request.uniqueId);
+    if (this.state.currentThermostatSuggestion?.uniqueId === request.uniqueId) {
+      this.state.currentThermostatSuggestion = null;
+    }
+    device.log.debug(`MatterbridgeThermostatServer: removeThermostatSuggestion completed for uniqueId: ${request.uniqueId}`);
   }
 }

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -32,6 +32,11 @@ import type { MatterbridgeEndpoint } from '../matterbridgeEndpoint.js';
 import type { ClusterAttributeValues } from '../matterbridgeEndpointCommandHandler.js';
 import { MatterbridgeServer } from './matterbridgeServer.js';
 
+/** Command id of the AtomicRequest command (Matter core spec § Atomic Write), not implemented by Matterbridge. */
+const ATOMIC_REQUEST_COMMAND_ID = 0xfe;
+/** Command id of the AtomicResponse command (Matter core spec § Atomic Write), not implemented by Matterbridge. */
+const ATOMIC_RESPONSE_COMMAND_ID = 0xfd;
+
 /**
  * Thermostat server (cooling/heating/auto/presets/schedules/suggestions) with Matterbridge-specific command handling.
  */
@@ -43,6 +48,26 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.MatterScheduleConfiguration,
   Thermostat.Feature.ThermostatSuggestions,
 ) {
+  /**
+   * Initializes thermostat behavior and removes the unsupported AtomicRequest/AtomicResponse commands from the
+   * command lists computed for the enabled features, instead of hard-coding the whole list.
+   */
+  override async initialize(): Promise<void> {
+    await super.initialize();
+
+    this.endpoint.construction.onSuccess(async () => {
+      const device = this.endpoint.stateOf(MatterbridgeServer);
+      device.log.debug(`Removing atomic commands (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
+      // cause acceptedCommandList and generatedCommandList are not typed in the cluster state
+      const { acceptedCommandList, generatedCommandList } = this.state as unknown as { acceptedCommandList: number[]; generatedCommandList: number[] };
+      // @ts-expect-error cause acceptedCommandList and generatedCommandList are not typed in the cluster state
+      await this.endpoint.setStateOf(ThermostatServer, {
+        acceptedCommandList: acceptedCommandList.filter((id) => id !== ATOMIC_REQUEST_COMMAND_ID),
+        generatedCommandList: generatedCommandList.filter((id) => id !== ATOMIC_RESPONSE_COMMAND_ID),
+      });
+    });
+  }
+
   /**
    * Forwards SetpointRaiseLower requests to the Matterbridge command handler and updates occupied setpoints.
    *
@@ -188,6 +213,7 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => s.uniqueId !== request.uniqueId);
     if (this.state.currentThermostatSuggestion?.uniqueId === request.uniqueId) {
       this.state.currentThermostatSuggestion = null;
+      this.state.thermostatSuggestionNotFollowingReason = null;
     }
     device.log.debug(`MatterbridgeThermostatServer: removeThermostatSuggestion completed for uniqueId: ${request.uniqueId}`);
   }

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3527,7 +3527,11 @@ export class MatterbridgeEndpoint extends Endpoint {
         ...(occupied !== undefined ? { occupancy: { occupied } } : {}),
         ...(occupied !== undefined ? { externallyMeasuredOccupancy: true } : {}),
         // Thermostat.Feature.Presets
-        numberOfPresets: Math.max(Array.isArray(presets) ? presets.length : 0, 10), // This attribute SHALL indicate the maximum number of entries supported by the Presets attribute.
+        numberOfPresets: Math.max(
+          Array.isArray(presets) ? presets.length : 0,
+          Array.isArray(presetTypes) ? Math.max(0, ...presetTypes.map((pt) => pt.numberOfPresets ?? 0)) : 0,
+          10,
+        ), // This attribute SHALL indicate the maximum number of entries supported by the Presets attribute, and must be consistent with the per-type capacities advertised in presetTypes.
         activePresetHandle: activePresetHandle ? Uint8Array.from(activePresetHandle) : null,
         // Ensure presetHandle is a proper Uint8Array by creating a new instance
         presets: (presets ?? []).map((p) => ({

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3437,6 +3437,137 @@ export class MatterbridgeEndpoint extends Endpoint {
   }
 
   /**
+   * Creates a default thermostat cluster server with features **Heating**, **Cooling**, **AutoMode**, **Presets** and **ThermostatSuggestions**.
+   *
+   * - When the occupied parameter is provided (either false or true), the **Occupancy** feature is also added (defaults to undefined).
+   * - When the outdoorTemperature parameter is provided (either null or a number), the outdoorTemperature attribute is also added (defaults to undefined).
+   * - The **ThermostatSuggestions** feature requires the **Presets** feature (a suggestion references a preset handle), so both are always added together.
+   *
+   * @param {number} [localTemperature] - The local temperature value in degrees Celsius. Defaults to 23°.
+   * @param {number} [occupiedHeatingSetpoint] - The occupied heating setpoint value in degrees Celsius. Defaults to 21°.
+   * @param {number} [occupiedCoolingSetpoint] - The occupied cooling setpoint value in degrees Celsius. Defaults to 25°.
+   * @param {number} [minSetpointDeadBand] - The minimum setpoint dead band value. Defaults to 0°.
+   * @param {number} [minHeatSetpointLimit] - The minimum heat setpoint limit value. Defaults to 0°.
+   * @param {number} [maxHeatSetpointLimit] - The maximum heat setpoint limit value. Defaults to 50°.
+   * @param {number} [minCoolSetpointLimit] - The minimum cool setpoint limit value. Defaults to 0°.
+   * @param {number} [maxCoolSetpointLimit] - The maximum cool setpoint limit value. Defaults to 50°.
+   * @param {number | undefined} [unoccupiedHeatingSetpoint] - The unoccupied heating setpoint value in degrees Celsius. Defaults to 19° (it will be ignored if occupied is not provided).
+   * @param {number | undefined} [unoccupiedCoolingSetpoint] - The unoccupied cooling setpoint value in degrees Celsius. Defaults to 27° (it will be ignored if occupied is not provided).
+   * @param {boolean | undefined} [occupied] - The occupancy status. Defaults to undefined (it will be ignored).
+   * @param {number | null | undefined} [outdoorTemperature] - The outdoor temperature value in degrees Celsius. Defaults to undefined (it will be ignored).
+   * @param {Uint8Array | null} [activePresetHandle] - The active preset handle. Defaults to null.
+   * @param {Thermostat.Preset[]} [presets] - The list of thermostat presets. Defaults to empty array.
+   * @param {Thermostat.PresetType[] | null | undefined} [presetTypes] - The list of thermostat preset types. Defaults to a predefined set.
+   * @param {Thermostat.ThermostatSuggestion[]} [thermostatSuggestions] - The list of thermostat suggestions. Defaults to empty array.
+   * @param {Thermostat.ThermostatSuggestion | null} [currentThermostatSuggestion] - The currently active thermostat suggestion. Defaults to null.
+   * @param {Thermostat.ThermostatSuggestionNotFollowingReason | null} [thermostatSuggestionNotFollowingReason] - The reason the current thermostat suggestion is not being followed. Defaults to null.
+   * @returns {this} The current MatterbridgeEndpoint instance for chaining.
+   *
+   * @remarks
+   * matter.js does not yet provide a default implementation of the AddThermostatSuggestion and RemoveThermostatSuggestion
+   * commands for the ThermostatSuggestions feature (it is not implemented by `ThermostatServer` in `@matter/node`), so
+   * Matterbridge validates the requests and maintains the `thermostatSuggestions` list itself.
+   */
+  createDefaultThermostatSuggestionsClusterServer(
+    localTemperature: number = 23,
+    occupiedHeatingSetpoint: number = 21,
+    occupiedCoolingSetpoint: number = 25,
+    minSetpointDeadBand: number = 0,
+    minHeatSetpointLimit: number = 0,
+    maxHeatSetpointLimit: number = 50,
+    minCoolSetpointLimit: number = 0,
+    maxCoolSetpointLimit: number = 50,
+    unoccupiedHeatingSetpoint?: number,
+    unoccupiedCoolingSetpoint?: number,
+    occupied?: boolean,
+    outdoorTemperature?: number | null,
+    activePresetHandle: Uint8Array | null = null,
+    presets: Thermostat.Preset[] = [],
+    presetTypes: Thermostat.PresetType[] = [
+      { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
+      { presetScenario: Thermostat.PresetScenario.Unoccupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
+    ],
+    thermostatSuggestions: Thermostat.ThermostatSuggestion[] = [],
+    currentThermostatSuggestion: Thermostat.ThermostatSuggestion | null = null,
+    thermostatSuggestionNotFollowingReason: Thermostat.ThermostatSuggestionNotFollowingReason | null = null,
+  ): this {
+    this.behaviors.require(
+      MatterbridgeThermostatServer.with(
+        Thermostat.Feature.Heating,
+        Thermostat.Feature.Cooling,
+        Thermostat.Feature.AutoMode,
+        ...(occupied !== undefined ? [Thermostat.Feature.Occupancy] : []),
+        Thermostat.Feature.Presets,
+        Thermostat.Feature.ThermostatSuggestions,
+      ),
+      {
+        localTemperature: localTemperature * 100,
+        externalMeasuredIndoorTemperature: localTemperature * 100,
+        ...(outdoorTemperature !== undefined ? { outdoorTemperature: outdoorTemperature !== null ? outdoorTemperature * 100 : outdoorTemperature } : {}), // Optional nullable attribute
+        systemMode: Thermostat.SystemMode.Auto,
+        controlSequenceOfOperation: Thermostat.ControlSequenceOfOperation.CoolingAndHeating,
+        // Thermostat.Feature.Heating
+        occupiedHeatingSetpoint: occupiedHeatingSetpoint * 100,
+        minHeatSetpointLimit: minHeatSetpointLimit * 100,
+        maxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+        absMinHeatSetpointLimit: minHeatSetpointLimit * 100,
+        absMaxHeatSetpointLimit: maxHeatSetpointLimit * 100,
+        // Thermostat.Feature.Cooling
+        occupiedCoolingSetpoint: occupiedCoolingSetpoint * 100,
+        minCoolSetpointLimit: minCoolSetpointLimit * 100,
+        maxCoolSetpointLimit: maxCoolSetpointLimit * 100,
+        absMinCoolSetpointLimit: minCoolSetpointLimit * 100,
+        absMaxCoolSetpointLimit: maxCoolSetpointLimit * 100,
+        // Thermostat.Feature.AutoMode
+        minSetpointDeadBand: minSetpointDeadBand * 10,
+        thermostatRunningMode: Thermostat.ThermostatRunningMode.Off,
+        // Thermostat.Feature.Occupancy
+        ...(occupied !== undefined ? { unoccupiedHeatingSetpoint: unoccupiedHeatingSetpoint !== undefined ? unoccupiedHeatingSetpoint * 100 : 1900 } : {}),
+        ...(occupied !== undefined ? { unoccupiedCoolingSetpoint: unoccupiedCoolingSetpoint !== undefined ? unoccupiedCoolingSetpoint * 100 : 2700 } : {}),
+        ...(occupied !== undefined ? { occupancy: { occupied } } : {}),
+        ...(occupied !== undefined ? { externallyMeasuredOccupancy: true } : {}),
+        // Thermostat.Feature.Presets
+        numberOfPresets: Math.max(Array.isArray(presets) ? presets.length : 0, 10), // This attribute SHALL indicate the maximum number of entries supported by the Presets attribute.
+        activePresetHandle: activePresetHandle ? Uint8Array.from(activePresetHandle) : null,
+        // Ensure presetHandle is a proper Uint8Array by creating a new instance
+        presets: (presets ?? []).map((p) => ({
+          presetHandle: p.presetHandle ? Uint8Array.from(p.presetHandle) : null, // Ensure presetHandle is a proper Uint8Array by creating a new instance
+          presetScenario: p.presetScenario,
+          name: p.name,
+          coolingSetpoint: p.coolingSetpoint,
+          heatingSetpoint: p.heatingSetpoint,
+          builtIn: p.builtIn ?? true,
+        })),
+        presetTypes: (presetTypes ?? []).map((pt) => ({
+          // oxlint-disable-next-line typescript/no-misused-spread
+          ...pt,
+          numberOfPresets: pt.numberOfPresets ?? 0,
+          presetTypeFeatures: pt.presetTypeFeatures ?? { automatic: false, supportsNames: true },
+        })),
+        // Thermostat.Feature.ThermostatSuggestions
+        maxThermostatSuggestions: Math.max(Array.isArray(thermostatSuggestions) ? thermostatSuggestions.length : 0, 5), // This attribute SHALL indicate the maximum number of entries supported by the ThermostatSuggestions attribute.
+        // Ensure presetHandle is a proper Uint8Array by creating a new instance
+        thermostatSuggestions: (thermostatSuggestions ?? []).map((s) => ({
+          uniqueId: s.uniqueId,
+          presetHandle: Uint8Array.from(s.presetHandle), // Ensure presetHandle is a proper Uint8Array by creating a new instance
+          effectiveTime: s.effectiveTime,
+          expirationTime: s.expirationTime,
+        })),
+        currentThermostatSuggestion: currentThermostatSuggestion
+          ? {
+              uniqueId: currentThermostatSuggestion.uniqueId,
+              presetHandle: Uint8Array.from(currentThermostatSuggestion.presetHandle), // Ensure presetHandle is a proper Uint8Array by creating a new instance
+              effectiveTime: currentThermostatSuggestion.effectiveTime,
+              expirationTime: currentThermostatSuggestion.expirationTime,
+            }
+          : null,
+        thermostatSuggestionNotFollowingReason: thermostatSuggestionNotFollowingReason ?? null,
+      },
+    );
+    return this;
+  }
+
+  /**
    * Creates a default cooling thermostat cluster server with feature **Cooling**.
    *
    * - When the occupied parameter is provided (either false or true), the **Occupancy** feature is also added (defaults to undefined).

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -3252,7 +3252,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     outdoorTemperature?: number | null,
     activePresetHandle: Uint8Array | null = null,
     presets: Thermostat.Preset[] = [],
-    presetTypes: Thermostat.PresetType[] = [
+    presetTypes: Thermostat.PresetType[] | null = [
       { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
       { presetScenario: Thermostat.PresetScenario.Unoccupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
     ],
@@ -3483,7 +3483,7 @@ export class MatterbridgeEndpoint extends Endpoint {
     outdoorTemperature?: number | null,
     activePresetHandle: Uint8Array | null = null,
     presets: Thermostat.Preset[] = [],
-    presetTypes: Thermostat.PresetType[] = [
+    presetTypes: Thermostat.PresetType[] | null = [
       { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
       { presetScenario: Thermostat.PresetScenario.Unoccupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
     ],

--- a/packages/core/src/matterbridgeEndpointCommandHandler.ts
+++ b/packages/core/src/matterbridgeEndpointCommandHandler.ts
@@ -544,6 +544,8 @@ export type CommandHandlerDataMap = {
   'setpointRaiseLower': CommandHandlerData<'Thermostat.setpointRaiseLower'>;
   'setActivePresetRequest': CommandHandlerData<'Thermostat.setActivePresetRequest'>;
   'setActiveScheduleRequest': CommandHandlerData<'Thermostat.setActiveScheduleRequest'>;
+  'addThermostatSuggestion': CommandHandlerData<'Thermostat.addThermostatSuggestion'>;
+  'removeThermostatSuggestion': CommandHandlerData<'Thermostat.removeThermostatSuggestion'>;
   'Thermostat.setpointRaiseLower': {
     command: 'setpointRaiseLower';
     request: Thermostat.SetpointRaiseLowerRequest;
@@ -561,6 +563,20 @@ export type CommandHandlerDataMap = {
   'Thermostat.setActiveScheduleRequest': {
     command: 'setActiveScheduleRequest';
     request: Thermostat.SetActiveScheduleRequest;
+    cluster: 'thermostat';
+    attributes: ClusterAttributeValues<(typeof Thermostat)['attributes']>;
+    endpoint: MatterbridgeEndpoint;
+  };
+  'Thermostat.addThermostatSuggestion': {
+    command: 'addThermostatSuggestion';
+    request: Thermostat.AddThermostatSuggestionRequest;
+    cluster: 'thermostat';
+    attributes: ClusterAttributeValues<(typeof Thermostat)['attributes']>;
+    endpoint: MatterbridgeEndpoint;
+  };
+  'Thermostat.removeThermostatSuggestion': {
+    command: 'removeThermostatSuggestion';
+    request: Thermostat.RemoveThermostatSuggestionRequest;
     cluster: 'thermostat';
     attributes: ClusterAttributeValues<(typeof Thermostat)['attributes']>;
     endpoint: MatterbridgeEndpoint;

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -116,6 +116,7 @@ describe('Server clusters and behaviors', () => {
   let thermo: MatterbridgeEndpoint;
   let thermostatPreset: MatterbridgeEndpoint;
   let thermostatSchedule: MatterbridgeEndpoint;
+  let thermostatSuggestion: MatterbridgeEndpoint;
   let valve: MatterbridgeEndpoint;
   let smoke: MatterbridgeEndpoint;
   let contact: MatterbridgeEndpoint;
@@ -201,6 +202,30 @@ describe('Server clusters and behaviors', () => {
       Uint8Array.from([0]), // activeScheduleHandle: Uint8Array | null
       thermostatSchedules, // schedules: Thermostat.Schedule[]
       thermostatScheduleTypes, // scheduleTypes: Thermostat.ScheduleType[]
+    );
+    endpoint.addRequiredClusterServers();
+    return endpoint;
+  }
+
+  function createThermostatSuggestionEndpoint(id: string): MatterbridgeEndpoint {
+    const endpoint = new MatterbridgeEndpoint(thermostat, { id });
+    endpoint.createDefaultThermostatSuggestionsClusterServer(
+      23,
+      21,
+      25,
+      2,
+      0,
+      48,
+      2,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Uint8Array.from([0]), // activePresetHandle: Uint8Array | null
+      thermostatPresets, // presetsList: Thermostat.Preset[]
+      thermostatPresetTypes, // presetTypesList: Thermostat.PresetType[]
+      [], // thermostatSuggestions: Thermostat.ThermostatSuggestion[]
     );
     endpoint.addRequiredClusterServers();
     return endpoint;
@@ -1161,6 +1186,83 @@ describe('Server clusters and behaviors', () => {
     expect(scheduleCalls).toHaveLength(2);
     // The active schedule handle must not change when the requested schedule handle is invalid.
     expect(thermostatSchedule.getAttribute(Thermostat.id, 'activeScheduleHandle')).toEqual(Uint8Array.from([1]));
+  });
+
+  test('ThermostatSuggestion server', async () => {
+    thermostatSuggestion = createThermostatSuggestionEndpoint('thermostatSuggestionBehavior');
+    expect(await addDevice(aggregator, thermostatSuggestion)).toBeTruthy();
+
+    const addCalls: Array<{ cluster: string; endpoint: MatterbridgeEndpoint; request: object }> = [];
+    const removeCalls: Array<{ cluster: string; endpoint: MatterbridgeEndpoint; request: object }> = [];
+
+    thermostatSuggestion.addCommandHandler('addThermostatSuggestion', (data) => {
+      addCalls.push({ cluster: data.cluster, endpoint: data.endpoint, request: data.request });
+    });
+    thermostatSuggestion.addCommandHandler('removeThermostatSuggestion', (data) => {
+      removeCalls.push({ cluster: data.cluster, endpoint: data.endpoint, request: data.request });
+    });
+
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'maxThermostatSuggestions')).toBe(5);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
+
+    // A suggestion referencing an existing preset with an explicit effectiveTime is accepted.
+    const explicitRequest = { presetHandle: Uint8Array.from([1]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', explicitRequest);
+    expect(addCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: explicitRequest });
+    let suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({ uniqueId: 0, effectiveTime: 1700000000, expirationTime: 1700001800 });
+    expect(JSON.stringify(Object.values(suggestions[0].presetHandle))).toBe(JSON.stringify([1]));
+
+    // A null effectiveTime means "immediately": the server fills in the current time.
+    const beforeNow = Math.floor(Date.now() / 1000);
+    const immediateRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: null, expirationInMinutes: 60 };
+    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', immediateRequest);
+    const afterNow = Math.floor(Date.now() / 1000);
+    expect(addCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: immediateRequest });
+    suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[1].uniqueId).toBe(1);
+    expect(suggestions[1].effectiveTime).toBeGreaterThanOrEqual(beforeNow);
+    expect(suggestions[1].effectiveTime).toBeLessThanOrEqual(afterNow);
+    expect(suggestions[1].expirationTime).toBe(suggestions[1].effectiveTime + 3600);
+
+    // An unknown PresetHandle is rejected, but the command is still forwarded to the command handler first.
+    const invalidPresetRequest = { presetHandle: Uint8Array.from([9]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', invalidPresetRequest)).rejects.toThrow('Requested PresetHandle not found');
+    expect(addCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidPresetRequest });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
+
+    // Fill the list up to MaxThermostatSuggestions (5), then the next add is rejected as ResourceExhausted.
+    for (let i = 0; i < 3; i++) {
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
+        presetHandle: Uint8Array.from([0]),
+        effectiveTime: 1700000000,
+        expirationInMinutes: 30,
+      });
+    }
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
+    const overflowRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', overflowRequest)).rejects.toThrow(
+      'Maximum number of thermostat suggestions reached',
+    );
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
+
+    // Simulate the thermostat currently following the first suggestion.
+    await thermostatSuggestion.setAttribute(Thermostat.id, 'currentThermostatSuggestion', suggestions[0]);
+
+    // Removing the current suggestion clears CurrentThermostatSuggestion.
+    const removeCurrentRequest = { uniqueId: 0 };
+    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeCurrentRequest);
+    expect(removeCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeCurrentRequest });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(4);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+
+    // An unknown UniqueID is rejected, but the command is still forwarded to the command handler first.
+    const invalidRemoveRequest = { uniqueId: 99 };
+    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', invalidRemoveRequest)).rejects.toThrow('Requested UniqueID not found');
+    expect(removeCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidRemoveRequest });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(4);
   });
 
   test('ValveConfigurationAndControl server', async () => {

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1215,16 +1215,17 @@ describe('Server clusters and behaviors', () => {
     expect(JSON.stringify(Object.values(suggestions[0].presetHandle))).toBe(JSON.stringify([1]));
 
     // A null effectiveTime means "immediately": the server fills in the current time.
-    const beforeNow = Math.floor(Date.now() / 1000);
+    const now = new Date('2026-01-15T10:00:00Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
     const immediateRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: null, expirationInMinutes: 60 };
     await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', immediateRequest);
-    const afterNow = Math.floor(Date.now() / 1000);
+    vi.useRealTimers();
     expect(addCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: immediateRequest });
     suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
     expect(suggestions).toHaveLength(2);
     expect(suggestions[1].uniqueId).toBe(1);
-    expect(suggestions[1].effectiveTime).toBeGreaterThanOrEqual(beforeNow);
-    expect(suggestions[1].effectiveTime).toBeLessThanOrEqual(afterNow);
+    expect(suggestions[1].effectiveTime).toBe(Math.floor(now.getTime() / 1000));
     expect(suggestions[1].expirationTime).toBe(suggestions[1].effectiveTime + 3600);
 
     // An unknown PresetHandle is rejected, but the command is still forwarded to the command handler first.

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -1660,6 +1660,134 @@ describe('Matterbridge ' + NAME, () => {
     expect(device.getAttribute(Thermostat.id, 'numberOfSchedules')).toBe(20);
   });
 
+  test('createDefaultThermostatSuggestionsClusterServer defaults', async () => {
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSuggestionsDefault' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultThermostatSuggestionsClusterServer();
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+    expect(device.hasAttributeServer(Thermostat.id, 'localTemperature')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'outdoorTemperature')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'systemMode')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupiedHeatingSetpoint')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupiedCoolingSetpoint')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'unoccupiedHeatingSetpoint')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'unoccupiedCoolingSetpoint')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'occupancy')).toBe(false);
+    expect(device.hasAttributeServer(Thermostat.id, 'numberOfPresets')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'activePresetHandle')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'presets')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'presetTypes')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'maxThermostatSuggestions')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'thermostatSuggestions')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'currentThermostatSuggestion')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBe(true);
+    expect(featuresFor(device, 'Thermostat')).toEqual({
+      autoMode: true,
+      cooling: true,
+      events: false,
+      heating: true,
+      localTemperatureNotExposed: false,
+      matterScheduleConfiguration: false,
+      occupancy: false,
+      presets: true,
+      setback: false,
+      thermostatSuggestions: true,
+    });
+
+    await addDevice(aggregator, device);
+    await flushAsync();
+    expect(device.getAttribute(Thermostat.id, 'systemMode')).toBe(Thermostat.SystemMode.Auto);
+    expect(device.getAttribute(Thermostat.id, 'numberOfPresets')).toBe(10);
+    expect(device.getAttribute(Thermostat.id, 'maxThermostatSuggestions')).toBe(5);
+    const retrievedThermostatSuggestions = device.getAttribute(Thermostat.id, 'thermostatSuggestions');
+    expect(retrievedThermostatSuggestions).toHaveLength(0);
+    expect(device.getCluster(Thermostat)).toMatchObject({
+      absMinHeatSetpointLimit: 0,
+      absMaxHeatSetpointLimit: 5000,
+      absMinCoolSetpointLimit: 0,
+      absMaxCoolSetpointLimit: 5000,
+      occupiedCoolingSetpoint: 2500,
+      occupiedHeatingSetpoint: 2100,
+      minHeatSetpointLimit: 0,
+      maxHeatSetpointLimit: 5000,
+      minCoolSetpointLimit: 0,
+      maxCoolSetpointLimit: 5000,
+      minSetpointDeadBand: 0,
+      numberOfPresets: 10,
+      activePresetHandle: null,
+      presets: [],
+      maxThermostatSuggestions: 5,
+      thermostatSuggestions: [],
+      currentThermostatSuggestion: null,
+      thermostatSuggestionNotFollowingReason: null,
+    });
+  });
+
+  test('createDefaultThermostatSuggestionsClusterServer', async () => {
+    const presetTypes: Thermostat.PresetType[] = [
+      { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
+      { presetScenario: Thermostat.PresetScenario.Unoccupied, numberOfPresets: 2, presetTypeFeatures: { automatic: false, supportsNames: true } },
+    ];
+    const presetsList: Thermostat.Preset[] = [
+      { presetHandle: Uint8Array.from([0]), presetScenario: Thermostat.PresetScenario.Occupied, name: 'Occupied', coolingSetpoint: 2500, heatingSetpoint: 2100, builtIn: null },
+      { presetHandle: Uint8Array.from([1]), presetScenario: Thermostat.PresetScenario.Unoccupied, name: 'Unoccupied', coolingSetpoint: 2700, heatingSetpoint: 1900, builtIn: null },
+    ];
+    const thermostatSuggestions: Thermostat.ThermostatSuggestion[] = [{ uniqueId: 0, presetHandle: Uint8Array.from([0]), effectiveTime: 1700000000, expirationTime: 1700003600 }];
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSuggestions' });
+    expect(device).toBeDefined();
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultThermostatSuggestionsClusterServer(
+      23,
+      21,
+      25,
+      2,
+      0,
+      48,
+      2,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Uint8Array.from([0]),
+      presetsList,
+      presetTypes,
+      thermostatSuggestions,
+      thermostatSuggestions[0],
+      null,
+    );
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+    expect(device.hasAttributeServer(Thermostat.id, 'maxThermostatSuggestions')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'thermostatSuggestions')).toBe(true);
+    expect(device.hasAttributeServer(Thermostat.id, 'currentThermostatSuggestion')).toBe(true);
+    expect(featuresFor(device, 'Thermostat')).toEqual({
+      autoMode: true,
+      cooling: true,
+      events: false,
+      heating: true,
+      localTemperatureNotExposed: false,
+      matterScheduleConfiguration: false,
+      occupancy: false,
+      presets: true,
+      setback: false,
+      thermostatSuggestions: true,
+    });
+
+    await addDevice(aggregator, device);
+    expect(device.getAttribute(Thermostat.id, 'maxThermostatSuggestions')).toBe(5);
+    const retrievedThermostatSuggestions = device.getAttribute(Thermostat.id, 'thermostatSuggestions');
+    expect(retrievedThermostatSuggestions).toHaveLength(1);
+    expect(JSON.stringify(Object.values(retrievedThermostatSuggestions[0].presetHandle))).toBe(JSON.stringify([0]));
+    expect(retrievedThermostatSuggestions[0].uniqueId).toBe(0);
+    expect(retrievedThermostatSuggestions[0].effectiveTime).toBe(1700000000);
+    expect(retrievedThermostatSuggestions[0].expirationTime).toBe(1700003600);
+    const retrievedCurrentThermostatSuggestion = device.getAttribute(Thermostat.id, 'currentThermostatSuggestion');
+    expect(retrievedCurrentThermostatSuggestion.uniqueId).toBe(0);
+    expect(JSON.stringify(Object.values(retrievedCurrentThermostatSuggestion.presetHandle))).toBe(JSON.stringify([0]));
+    expect(device.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
+  });
+
   test('createDefaultFanControlClusterServer', async () => {
     const device = new MatterbridgeEndpoint(fan, { id: 'Fan' });
     expect(device).toBeDefined();

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -1788,6 +1788,20 @@ describe('Matterbridge ' + NAME, () => {
     expect(device.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
   });
 
+  test('createDefaultThermostatSuggestionsClusterServer numberOfPresets reflects presetTypes capacity', async () => {
+    const presetTypes: Thermostat.PresetType[] = [
+      { presetScenario: Thermostat.PresetScenario.Occupied, numberOfPresets: 20, presetTypeFeatures: { automatic: false, supportsNames: true } },
+    ];
+    const device = new MatterbridgeEndpoint(thermostat, { id: 'ThermoSuggestionsCapacity' });
+    device.createDefaultIdentifyClusterServer();
+    device.createDefaultThermostatSuggestionsClusterServer(23, 21, 25, 2, 0, 48, 2, 50, undefined, undefined, undefined, undefined, null, [], presetTypes);
+    device.createDefaultThermostatUserInterfaceConfigurationClusterServer();
+
+    await addDevice(aggregator, device);
+    // numberOfPresets must not report less than the capacity advertised in presetTypes.
+    expect(device.getAttribute(Thermostat.id, 'numberOfPresets')).toBe(20);
+  });
+
   test('createDefaultFanControlClusterServer', async () => {
     const device = new MatterbridgeEndpoint(fan, { id: 'Fan' });
     expect(device).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds the **ThermostatSuggestions** feature (`Thermostat.Feature.ThermostatSuggestions`, TSUGGEST)
  to `MatterbridgeThermostatServer`, mirroring the existing Presets support: default attributes
  (`maxThermostatSuggestions`, `thermostatSuggestions`, `currentThermostatSuggestion`,
  `thermostatSuggestionNotFollowingReason`) via a new `createDefaultThermostatSuggestionsClusterServer()`
  helper (always paired with Presets, since TSUGGEST has conformance `[PRES]`).
- Adds `addThermostatSuggestion` / `removeThermostatSuggestion` command overrides that validate the request, maintain the `thermostatSuggestions` list, generate `UniqueID`s, and clean up `currentThermostatSuggestion` — `matter.js`'s own `ThermostatServer` does not implement these commands yet.
- Removed the obsolete `AtomicRequest`/`AtomicResponse` command-list workaround that had been unintentionally reintroduced while addressing review feedback; `dev` (`314450a`) already dropped this same workaround since `matter.js` now handles the atomic-write commands correctly.
- Aligned `numberOfPresets` in `createDefaultThermostatSuggestionsClusterServer` with the Matter spec minimum (`min 1`, per `@matter/model`), matching the other two Presets/Schedules helpers. `maxThermostatSuggestions` keeps its `Math.max(count, 5)` floor — verified against `@matter/model`'s `thermostat-cluster` element that `MaxThermostatSuggestions` has its own independent spec constraint of `min 5`, unlike `NumberOfPresets`/`NumberOfSchedules` which derive from per-type capacity lists.
- `addThermostatSuggestion` now validates `ExpirationInMinutes` (must be a positive integer) and `EffectiveTime` (must be a non-negative integer when provided), rejecting malformed input with `InvalidCommandError` instead of producing invalid/NaN timestamps.

## Test plan

- [x] `packages/core` unit tests (`vitest/behaviors/matterbridgeServer.test.ts`,
      `vitest/matterbridgeEndpoint-default.test.ts`) — 119/119 passing, including new coverage for the
      `ExpirationInMinutes`/`EffectiveTime` validation.
- [x] `npm run build`
- [x] `npm run lint` (oxlint)
- [x] `npm run format -- --check` (oxfmt)
