### PR TITLE
fix(thermostat): apply thermostat suggestions (re-evaluate CurrentThermostatSuggestion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ If you like this project and find it useful, please consider giving it a star on
 - [frontend]: Bump `oxfmt` to v.0.63.0.
 - [frontend]: Bump `oxlint` to v.1.78.0.
 
+### Fixed
+
+- [thermostat]: Apply thermostat suggestions: `AddThermostatSuggestion`/`RemoveThermostatSuggestion` now re-evaluate `CurrentThermostatSuggestion`, syncing `ActivePresetHandle` and clearing `ThermostatSuggestionNotFollowingReason`, and prune expired entries from `ThermostatSuggestions`. Thanks Ludovic BOUÉ.
+
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 
 ## [3.10.5] - 2026-08-14

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -119,7 +119,7 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   }
 
   /**
-   * Removes expired entries (ExpirationTime in the past) from ThermostatSuggestions, mirroring
+   * Removes expired entries (ExpirationTime at or before now) from ThermostatSuggestions, mirroring
    * `RemoveExpiredSuggestions()` in connectedhomeip's `src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp`.
    */
   private removeExpiredThermostatSuggestions(): void {
@@ -130,9 +130,10 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   /**
    * Re-evaluates CurrentThermostatSuggestion, mirroring `ReEvaluateCurrentSuggestion()` in connectedhomeip's
    * `examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp`: the suggestion with the earliest
-   * EffectiveTime among those already active (EffectiveTime <= now) becomes current. When a new suggestion becomes
-   * current, ActivePresetHandle is synced to it and ThermostatSuggestionNotFollowingReason is cleared; when no
-   * suggestion is active, CurrentThermostatSuggestion is cleared but ActivePresetHandle is left untouched.
+   * EffectiveTime among those already active (EffectiveTime <= now) becomes current. ThermostatSuggestionNotFollowingReason
+   * is cleared whenever CurrentThermostatSuggestion changes, including when it becomes null, so it never keeps
+   * describing a suggestion that is no longer current. When a new suggestion becomes current, ActivePresetHandle is
+   * synced to it; when no suggestion is active, ActivePresetHandle is left untouched.
    */
   private reEvaluateCurrentThermostatSuggestion(): void {
     const now = Math.floor(Date.now() / 1000);
@@ -142,9 +143,9 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     }
     if (this.state.currentThermostatSuggestion?.uniqueId === current?.uniqueId) return;
     this.state.currentThermostatSuggestion = current;
+    this.state.thermostatSuggestionNotFollowingReason = null;
     if (current !== null) {
       this.state.activePresetHandle = Uint8Array.from(current.presetHandle);
-      this.state.thermostatSuggestionNotFollowingReason = null;
     }
   }
 

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -176,7 +176,10 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
       throw new StatusResponse.NotFoundError('Requested PresetHandle not found');
     }
     // Remove expired suggestions before checking capacity, so a list full of stale entries does not block a valid add.
+    // Re-evaluate immediately after pruning so CurrentThermostatSuggestion/ActivePresetHandle stay consistent even if a
+    // later validation (capacity, EffectiveTime) rejects this command.
     this.removeExpiredThermostatSuggestions();
+    this.reEvaluateCurrentThermostatSuggestion();
     if (this.state.thermostatSuggestions.length >= this.state.maxThermostatSuggestions) {
       throw new StatusResponse.ResourceExhaustedError('Maximum number of thermostat suggestions reached');
     }

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -119,6 +119,36 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   }
 
   /**
+   * Removes expired entries (ExpirationTime in the past) from ThermostatSuggestions, mirroring
+   * `RemoveExpiredSuggestions()` in connectedhomeip's `src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp`.
+   */
+  private removeExpiredThermostatSuggestions(): void {
+    const now = Math.floor(Date.now() / 1000);
+    this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => s.expirationTime > now);
+  }
+
+  /**
+   * Re-evaluates CurrentThermostatSuggestion, mirroring `ReEvaluateCurrentSuggestion()` in connectedhomeip's
+   * `examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp`: the suggestion with the earliest
+   * EffectiveTime among those already active (EffectiveTime <= now) becomes current. When a new suggestion becomes
+   * current, ActivePresetHandle is synced to it and ThermostatSuggestionNotFollowingReason is cleared; when no
+   * suggestion is active, CurrentThermostatSuggestion is cleared but ActivePresetHandle is left untouched.
+   */
+  private reEvaluateCurrentThermostatSuggestion(): void {
+    const now = Math.floor(Date.now() / 1000);
+    let current: Thermostat.ThermostatSuggestion | null = null;
+    for (const s of this.state.thermostatSuggestions) {
+      if (s.effectiveTime <= now && (current === null || s.effectiveTime < current.effectiveTime)) current = s;
+    }
+    if (this.state.currentThermostatSuggestion?.uniqueId === current?.uniqueId) return;
+    this.state.currentThermostatSuggestion = current;
+    if (current !== null) {
+      this.state.activePresetHandle = Uint8Array.from(current.presetHandle);
+      this.state.thermostatSuggestionNotFollowingReason = null;
+    }
+  }
+
+  /**
    * Forwards AddThermostatSuggestion requests to the Matterbridge command handler and appends the new suggestion.
    *
    * @param {Thermostat.AddThermostatSuggestionRequest} request - Add-thermostat-suggestion request payload.
@@ -126,7 +156,8 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
    *
    * @remarks
    * matter.js does not yet provide a default implementation of this command (the ThermostatSuggestions feature
-   * is not implemented by `ThermostatServer` in `@matter/node`), so validation and list bookkeeping are done here.
+   * is not implemented by `ThermostatServer` in `@matter/node`), so validation, list bookkeeping, and applying the
+   * suggestion (re-evaluating CurrentThermostatSuggestion / ActivePresetHandle) are done here.
    */
   override async addThermostatSuggestion(request: Thermostat.AddThermostatSuggestionRequest): Promise<Thermostat.AddThermostatSuggestionResponse> {
     const device = this.endpoint.stateOf(MatterbridgeServer);
@@ -143,6 +174,8 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     if (this.state.presets.find((p) => p.presetHandle !== null && Bytes.areEqual(p.presetHandle, request.presetHandle)) === undefined) {
       throw new StatusResponse.NotFoundError('Requested PresetHandle not found');
     }
+    // Remove expired suggestions before checking capacity, so a list full of stale entries does not block a valid add.
+    this.removeExpiredThermostatSuggestions();
     if (this.state.thermostatSuggestions.length >= this.state.maxThermostatSuggestions) {
       throw new StatusResponse.ResourceExhaustedError('Maximum number of thermostat suggestions reached');
     }
@@ -161,6 +194,7 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
       expirationTime: effectiveTime + request.expirationInMinutes * 60,
     };
     this.state.thermostatSuggestions = [...this.state.thermostatSuggestions, suggestion];
+    this.reEvaluateCurrentThermostatSuggestion();
     device.log.debug(`MatterbridgeThermostatServer: addThermostatSuggestion completed with uniqueId: ${uniqueId}`);
     return { uniqueId };
   }
@@ -172,7 +206,8 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
    *
    * @remarks
    * matter.js does not yet provide a default implementation of this command (the ThermostatSuggestions feature
-   * is not implemented by `ThermostatServer` in `@matter/node`), so validation and list bookkeeping are done here.
+   * is not implemented by `ThermostatServer` in `@matter/node`), so validation, list bookkeeping, and applying the
+   * next suggestion (re-evaluating CurrentThermostatSuggestion / ActivePresetHandle) are done here.
    */
   override async removeThermostatSuggestion(request: Thermostat.RemoveThermostatSuggestionRequest): Promise<void> {
     const device = this.endpoint.stateOf(MatterbridgeServer);
@@ -190,10 +225,8 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
       throw new StatusResponse.NotFoundError('Requested UniqueID not found');
     }
     this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => s.uniqueId !== request.uniqueId);
-    if (this.state.currentThermostatSuggestion?.uniqueId === request.uniqueId) {
-      this.state.currentThermostatSuggestion = null;
-      this.state.thermostatSuggestionNotFollowingReason = null;
-    }
+    this.removeExpiredThermostatSuggestions();
+    this.reEvaluateCurrentThermostatSuggestion();
     device.log.debug(`MatterbridgeThermostatServer: removeThermostatSuggestion completed for uniqueId: ${request.uniqueId}`);
   }
 }

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1204,84 +1204,105 @@ describe('Server clusters and behaviors', () => {
 
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'maxThermostatSuggestions')).toBe(5);
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
 
-    // A suggestion referencing an existing preset with an explicit effectiveTime is accepted.
-    const explicitRequest = { presetHandle: Uint8Array.from([1]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    // Freeze the clock so EffectiveTime/ExpirationTime comparisons below are deterministic.
+    const now = new Date('2026-01-15T10:00:00Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const nowSeconds = Math.floor(now.getTime() / 1000);
+
+    // A suggestion referencing an existing preset that is already effective (EffectiveTime in the past) is accepted
+    // and immediately applied: CurrentThermostatSuggestion, ActivePresetHandle and ThermostatSuggestionNotFollowingReason
+    // are updated, mirroring connectedhomeip's ReEvaluateCurrentSuggestion().
+    const explicitRequest = { presetHandle: Uint8Array.from([1]), effectiveTime: nowSeconds - 60, expirationInMinutes: 30 };
     await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', explicitRequest);
     expect(addCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: explicitRequest });
     let suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
     expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]).toMatchObject({ uniqueId: 0, effectiveTime: 1700000000, expirationTime: 1700001800 });
+    expect(suggestions[0]).toMatchObject({ uniqueId: 0, effectiveTime: nowSeconds - 60, expirationTime: nowSeconds - 60 + 1800 });
     expect(JSON.stringify(Object.values(suggestions[0].presetHandle))).toBe(JSON.stringify([1]));
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
 
-    // A null effectiveTime means "immediately": the server fills in the current time.
-    const now = new Date('2026-01-15T10:00:00Z');
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
+    // A null effectiveTime means "immediately": the server fills in the current time. Since the first suggestion
+    // became effective earlier, it keeps being the earliest active one and stays current.
     const immediateRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: null, expirationInMinutes: 60 };
     await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', immediateRequest);
-    vi.useRealTimers();
     expect(addCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: immediateRequest });
     suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
     expect(suggestions).toHaveLength(2);
     expect(suggestions[1].uniqueId).toBe(1);
-    expect(suggestions[1].effectiveTime).toBe(Math.floor(now.getTime() / 1000));
-    expect(suggestions[1].expirationTime).toBe(suggestions[1].effectiveTime + 3600);
+    expect(suggestions[1].effectiveTime).toBe(nowSeconds);
+    expect(suggestions[1].expirationTime).toBe(nowSeconds + 3600);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
 
     // An EffectiveTime more than 24 hours in the future is rejected.
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
-    const futureRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: Math.floor(now.getTime() / 1000) + 24 * 60 * 60 + 1, expirationInMinutes: 30 };
+    const futureRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds + 24 * 60 * 60 + 1, expirationInMinutes: 30 };
     await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', futureRequest)).rejects.toThrow(
       'EffectiveTime cannot be more than 24 hours in the future',
     );
-    vi.useRealTimers();
     expect(addCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: futureRequest });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
 
     // An unknown PresetHandle is rejected, but the command is still forwarded to the command handler first.
-    const invalidPresetRequest = { presetHandle: Uint8Array.from([9]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    const invalidPresetRequest = { presetHandle: Uint8Array.from([9]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
     await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', invalidPresetRequest)).rejects.toThrow('Requested PresetHandle not found');
     expect(addCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidPresetRequest });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
 
-    // Fill the list up to MaxThermostatSuggestions (5), then the next add is rejected as ResourceExhausted.
+    // Fill the list up to MaxThermostatSuggestions (5) with suggestions that are not yet effective (2+ hours out),
+    // then the next add is rejected as ResourceExhausted. None of them preempt the already-active current one.
     for (let i = 0; i < 3; i++) {
       await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
         presetHandle: Uint8Array.from([0]),
-        effectiveTime: 1700000000,
+        effectiveTime: nowSeconds + 7200 + i * 60,
         expirationInMinutes: 30,
       });
     }
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
-    const overflowRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: 1700000000, expirationInMinutes: 30 };
+    const overflowRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
     await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', overflowRequest)).rejects.toThrow(
       'Maximum number of thermostat suggestions reached',
     );
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
 
-    // Simulate the thermostat currently following the first suggestion.
-    await thermostatSuggestion.setAttribute(Thermostat.id, 'currentThermostatSuggestion', suggestions[0]);
-
-    // Removing a different suggestion keeps CurrentThermostatSuggestion unchanged.
-    const removeOtherRequest = { uniqueId: 1 };
+    // Removing a different, not-yet-effective suggestion (uniqueId 4) keeps CurrentThermostatSuggestion unchanged.
+    const removeOtherRequest = { uniqueId: 4 };
     await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeOtherRequest);
     expect(removeCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeOtherRequest });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(4);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toEqual(suggestions[0]);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
 
-    // Removing the current suggestion clears CurrentThermostatSuggestion.
+    // Removing the current suggestion (uniqueId 0) re-evaluates and applies the next earliest already-active one
+    // (uniqueId 1), syncing ActivePresetHandle to it: the thermostat keeps following a suggestion automatically.
     const removeCurrentRequest = { uniqueId: 0 };
     await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeCurrentRequest);
     expect(removeCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeCurrentRequest });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 1 });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
 
     // An unknown UniqueID is rejected, but the command is still forwarded to the command handler first.
     const invalidRemoveRequest = { uniqueId: 99 };
     await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', invalidRemoveRequest)).rejects.toThrow('Requested UniqueID not found');
     expect(removeCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidRemoveRequest });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
+
+    // Once the current suggestion's ExpirationTime elapses and no other suggestion is effective yet, the next
+    // add/remove call prunes the expired entry and clears CurrentThermostatSuggestion; ActivePresetHandle, which
+    // reflects the last-followed preset, is intentionally left untouched (mirrors the reference behavior).
+    vi.setSystemTime(new Date((nowSeconds + 3601) * 1000));
+    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 3 });
+    expect(removeCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: { uniqueId: 3 } });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(1);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
+
+    vi.useRealTimers();
   });
 
   test('ValveConfigurationAndControl server', async () => {

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1307,6 +1307,40 @@ describe('Server clusters and behaviors', () => {
       expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
       expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
       expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
+
+      // A suggestion that becomes current, then expires, is pruned and re-evaluated as part of the next add/remove
+      // call. If that call is itself rejected by a later validation (here EffectiveTime > 24h in the future), the
+      // prune/re-evaluate performed earlier in the same command must not leak out: matter.js runs each command in
+      // its own transaction and discards every mutation when the handler throws (LocalActorContext.act rejects the
+      // transaction on error), so CurrentThermostatSuggestion/ThermostatSuggestions/ActivePresetHandle/
+      // ThermostatSuggestionNotFollowingReason stay exactly as they were before the rejected command.
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
+        presetHandle: Uint8Array.from([1]),
+        effectiveTime: null,
+        expirationInMinutes: 1,
+      });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+
+      await thermostatSuggestion.setAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason', { ongoingHold: true });
+      vi.setSystemTime(new Date(Date.now() + 61_000)); // past the uniqueId 0 suggestion's 1-minute ExpirationTime
+      const currentSeconds = Math.floor(Date.now() / 1000);
+      const rejectedRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: currentSeconds + 25 * 60 * 60, expirationInMinutes: 30 };
+      await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', rejectedRequest)).rejects.toThrow(
+        'EffectiveTime cannot be more than 24 hours in the future',
+      );
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toMatchObject({ ongoingHold: true });
+
+      // The next successful command finally prunes the now-expired suggestion and re-evaluates: CurrentThermostatSuggestion
+      // becomes null and ThermostatSuggestionNotFollowingReason is cleared; ActivePresetHandle is left untouched.
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 2 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1209,100 +1209,107 @@ describe('Server clusters and behaviors', () => {
     // Freeze the clock so EffectiveTime/ExpirationTime comparisons below are deterministic.
     const now = new Date('2026-01-15T10:00:00Z');
     vi.useFakeTimers();
-    vi.setSystemTime(now);
-    const nowSeconds = Math.floor(now.getTime() / 1000);
+    try {
+      vi.setSystemTime(now);
+      const nowSeconds = Math.floor(now.getTime() / 1000);
 
-    // A suggestion referencing an existing preset that is already effective (EffectiveTime in the past) is accepted
-    // and immediately applied: CurrentThermostatSuggestion, ActivePresetHandle and ThermostatSuggestionNotFollowingReason
-    // are updated, mirroring connectedhomeip's ReEvaluateCurrentSuggestion().
-    const explicitRequest = { presetHandle: Uint8Array.from([1]), effectiveTime: nowSeconds - 60, expirationInMinutes: 30 };
-    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', explicitRequest);
-    expect(addCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: explicitRequest });
-    let suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
-    expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]).toMatchObject({ uniqueId: 0, effectiveTime: nowSeconds - 60, expirationTime: nowSeconds - 60 + 1800 });
-    expect(JSON.stringify(Object.values(suggestions[0].presetHandle))).toBe(JSON.stringify([1]));
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
+      // A suggestion referencing an existing preset that is already effective (EffectiveTime in the past) is accepted
+      // and immediately applied: CurrentThermostatSuggestion, ActivePresetHandle and ThermostatSuggestionNotFollowingReason
+      // are updated, mirroring connectedhomeip's ReEvaluateCurrentSuggestion().
+      const explicitRequest = { presetHandle: Uint8Array.from([1]), effectiveTime: nowSeconds - 60, expirationInMinutes: 30 };
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', explicitRequest);
+      expect(addCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: explicitRequest });
+      let suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0]).toMatchObject({ uniqueId: 0, effectiveTime: nowSeconds - 60, expirationTime: nowSeconds - 60 + 1800 });
+      expect(JSON.stringify(Object.values(suggestions[0].presetHandle))).toBe(JSON.stringify([1]));
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
 
-    // A null effectiveTime means "immediately": the server fills in the current time. Since the first suggestion
-    // became effective earlier, it keeps being the earliest active one and stays current.
-    const immediateRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: null, expirationInMinutes: 60 };
-    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', immediateRequest);
-    expect(addCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: immediateRequest });
-    suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
-    expect(suggestions).toHaveLength(2);
-    expect(suggestions[1].uniqueId).toBe(1);
-    expect(suggestions[1].effectiveTime).toBe(nowSeconds);
-    expect(suggestions[1].expirationTime).toBe(nowSeconds + 3600);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
+      // A null effectiveTime means "immediately": the server fills in the current time. Since the first suggestion
+      // became effective earlier, it keeps being the earliest active one and stays current.
+      const immediateRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: null, expirationInMinutes: 60 };
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', immediateRequest);
+      expect(addCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: immediateRequest });
+      suggestions = thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions');
+      expect(suggestions).toHaveLength(2);
+      expect(suggestions[1].uniqueId).toBe(1);
+      expect(suggestions[1].effectiveTime).toBe(nowSeconds);
+      expect(suggestions[1].expirationTime).toBe(nowSeconds + 3600);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([1]));
 
-    // An EffectiveTime more than 24 hours in the future is rejected.
-    const futureRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds + 24 * 60 * 60 + 1, expirationInMinutes: 30 };
-    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', futureRequest)).rejects.toThrow(
-      'EffectiveTime cannot be more than 24 hours in the future',
-    );
-    expect(addCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: futureRequest });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
+      // An EffectiveTime more than 24 hours in the future is rejected.
+      const futureRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds + 24 * 60 * 60 + 1, expirationInMinutes: 30 };
+      await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', futureRequest)).rejects.toThrow(
+        'EffectiveTime cannot be more than 24 hours in the future',
+      );
+      expect(addCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: futureRequest });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
 
-    // An unknown PresetHandle is rejected, but the command is still forwarded to the command handler first.
-    const invalidPresetRequest = { presetHandle: Uint8Array.from([9]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
-    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', invalidPresetRequest)).rejects.toThrow('Requested PresetHandle not found');
-    expect(addCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidPresetRequest });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
+      // An unknown PresetHandle is rejected, but the command is still forwarded to the command handler first.
+      const invalidPresetRequest = { presetHandle: Uint8Array.from([9]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
+      await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', invalidPresetRequest)).rejects.toThrow('Requested PresetHandle not found');
+      expect(addCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidPresetRequest });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(2);
 
-    // Fill the list up to MaxThermostatSuggestions (5) with suggestions that are not yet effective (2+ hours out),
-    // then the next add is rejected as ResourceExhausted. None of them preempt the already-active current one.
-    for (let i = 0; i < 3; i++) {
-      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
-        presetHandle: Uint8Array.from([0]),
-        effectiveTime: nowSeconds + 7200 + i * 60,
-        expirationInMinutes: 30,
-      });
+      // Fill the list up to MaxThermostatSuggestions (5) with suggestions that are not yet effective (2+ hours out),
+      // then the next add is rejected as ResourceExhausted. None of them preempt the already-active current one.
+      for (let i = 0; i < 3; i++) {
+        await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
+          presetHandle: Uint8Array.from([0]),
+          effectiveTime: nowSeconds + 7200 + i * 60,
+          expirationInMinutes: 30,
+        });
+      }
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
+      const overflowRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
+      await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', overflowRequest)).rejects.toThrow(
+        'Maximum number of thermostat suggestions reached',
+      );
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+
+      // Removing a different, not-yet-effective suggestion (uniqueId 4) keeps CurrentThermostatSuggestion unchanged.
+      const removeOtherRequest = { uniqueId: 4 };
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeOtherRequest);
+      expect(removeCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeOtherRequest });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(4);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
+
+      // Removing the current suggestion (uniqueId 0) re-evaluates and applies the next earliest already-active one
+      // (uniqueId 1), syncing ActivePresetHandle to it: the thermostat keeps following a suggestion automatically.
+      const removeCurrentRequest = { uniqueId: 0 };
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeCurrentRequest);
+      expect(removeCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeCurrentRequest });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 1 });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
+
+      // An unknown UniqueID is rejected, but the command is still forwarded to the command handler first.
+      const invalidRemoveRequest = { uniqueId: 99 };
+      await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', invalidRemoveRequest)).rejects.toThrow('Requested UniqueID not found');
+      expect(removeCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidRemoveRequest });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
+
+      // Once the current suggestion's ExpirationTime elapses and no other suggestion is effective yet, the next
+      // add/remove call prunes the expired entry and clears CurrentThermostatSuggestion; ActivePresetHandle, which
+      // reflects the last-followed preset, is intentionally left untouched (mirrors the reference behavior).
+      // ThermostatSuggestionNotFollowingReason is set here to a non-null value beforehand to verify it is cleared
+      // alongside CurrentThermostatSuggestion rather than leaking a stale reason (Matter spec: "If the
+      // CurrentThermostatSuggestion attribute is null, this attribute shall be set to null").
+      await thermostatSuggestion.setAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason', { ongoingHold: true });
+      vi.setSystemTime(new Date((nowSeconds + 3601) * 1000));
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 3 });
+      expect(removeCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: { uniqueId: 3 } });
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(1);
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestionNotFollowingReason')).toBeNull();
+    } finally {
+      vi.useRealTimers();
     }
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
-    const overflowRequest = { presetHandle: Uint8Array.from([0]), effectiveTime: nowSeconds, expirationInMinutes: 30 };
-    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', overflowRequest)).rejects.toThrow(
-      'Maximum number of thermostat suggestions reached',
-    );
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(5);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
-
-    // Removing a different, not-yet-effective suggestion (uniqueId 4) keeps CurrentThermostatSuggestion unchanged.
-    const removeOtherRequest = { uniqueId: 4 };
-    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeOtherRequest);
-    expect(removeCalls[0]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeOtherRequest });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(4);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 0 });
-
-    // Removing the current suggestion (uniqueId 0) re-evaluates and applies the next earliest already-active one
-    // (uniqueId 1), syncing ActivePresetHandle to it: the thermostat keeps following a suggestion automatically.
-    const removeCurrentRequest = { uniqueId: 0 };
-    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', removeCurrentRequest);
-    expect(removeCalls[1]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: removeCurrentRequest });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ uniqueId: 1 });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
-
-    // An unknown UniqueID is rejected, but the command is still forwarded to the command handler first.
-    const invalidRemoveRequest = { uniqueId: 99 };
-    await expect(thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', invalidRemoveRequest)).rejects.toThrow('Requested UniqueID not found');
-    expect(removeCalls[2]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: invalidRemoveRequest });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
-
-    // Once the current suggestion's ExpirationTime elapses and no other suggestion is effective yet, the next
-    // add/remove call prunes the expired entry and clears CurrentThermostatSuggestion; ActivePresetHandle, which
-    // reflects the last-followed preset, is intentionally left untouched (mirrors the reference behavior).
-    vi.setSystemTime(new Date((nowSeconds + 3601) * 1000));
-    await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'removeThermostatSuggestion', { uniqueId: 3 });
-    expect(removeCalls[3]).toEqual({ cluster: 'thermostat', endpoint: thermostatSuggestion, request: { uniqueId: 3 } });
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(1);
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
-    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'activePresetHandle')).toEqual(Uint8Array.from([0]));
-
-    vi.useRealTimers();
   });
 
   test('ValveConfigurationAndControl server', async () => {


### PR DESCRIPTION
## Summary

`MatterbridgeThermostatServer.addThermostatSuggestion`/`removeThermostatSuggestion` only did list bookkeeping (append/remove, uniqueId, expirationTime): `CurrentThermostatSuggestion`, `ActivePresetHandle` and `ThermostatSuggestionNotFollowingReason` were never updated, so a suggestion was never actually "applied" and the list only ever grew.

Adds the missing re-evaluation logic, mirroring connectedhomeip's thermostat-server reference implementation (`src/app/clusters/thermostat-server/ThermostatClusterSuggestions.cpp` and `examples/thermostat/thermostat-common/src/thermostat-delegate-impl.cpp`):

- `removeExpiredThermostatSuggestions()` — drops entries whose `ExpirationTime` has elapsed, matching `RemoveExpiredSuggestions()`.
- `reEvaluateCurrentThermostatSuggestion()` — picks the suggestion with the earliest `EffectiveTime` among those already active (`EffectiveTime <= now`) as `CurrentThermostatSuggestion`, syncing `ActivePresetHandle` when a suggestion becomes current, matching `ReEvaluateCurrentSuggestion()`. `ThermostatSuggestionNotFollowingReason` is cleared whenever `CurrentThermostatSuggestion` changes — including when it becomes `null` — per the Matter spec requirement that this attribute be `null` whenever `CurrentThermostatSuggestion` is `null`. When no suggestion is active, `CurrentThermostatSuggestion` is cleared but `ActivePresetHandle` is left untouched, per the same reference behavior.

Both helpers now run after every `AddThermostatSuggestion`/`RemoveThermostatSuggestion`, so the device actually follows its suggestions and self-heals expired ones without needing a plugin-side polling workaround.

## Testing

Rewrote the `ThermostatSuggestion server` test to freeze the clock (`vi.useFakeTimers`) for deterministic `EffectiveTime`/`ExpirationTime` comparisons and cover: immediate application on add, earliest-active-wins when suggestions overlap, automatic hand-off to the next suggestion on remove, expiration pruning, and `ThermostatSuggestionNotFollowingReason` being cleared once `CurrentThermostatSuggestion` becomes `null`. The fake-timer section is now wrapped in `try`/`finally` so a failing assertion can't leak fake timers into later tests.

```
npm run lint -- packages/core/src/behaviors/thermostatServer.ts packages/core/vitest/behaviors/matterbridgeServer.test.ts
npm run typecheck
npx vitest run vitest/behaviors/matterbridgeServer.test.ts   # 42 passed
```

Also validated live against two real controllers on a build of this branch (see comments below): `chip-tool` and a third-party dashboard (matterjs-server) — both confirm `CurrentThermostatSuggestion`/`ActivePresetHandle` update automatically on `Add`/`RemoveThermostatSuggestion`, with the pre-existing, earlier-effective suggestion correctly staying current over a later-effective one that's also active.

## Review feedback addressed

Addressed all 3 inline Copilot review comments:

- `ThermostatSuggestionNotFollowingReason` is now cleared whenever `CurrentThermostatSuggestion` changes, including when it becomes `null` (previously only cleared when a new suggestion became current), matching the Matter spec's `null`-when-`null` requirement.
- Fixed the `removeExpiredThermostatSuggestions()` JSDoc wording to describe the actual inclusive expiration boundary (`expirationTime <= now` is expired).
- Wrapped the `ThermostatSuggestion server` test body in `try`/`finally` around `vi.useFakeTimers()`/`vi.useRealTimers()` to prevent fake-timer leakage into later tests on assertion failure.

The branch was also rebased and force-pushed to drop unrelated commits that had ended up on it (Closure/MicrowaveOven/Atomic-request changes already present on `dev`); it now contains only this fix on top of current `dev`.

## Known limitation

Re-evaluation is purely **event-driven**: `removeExpiredThermostatSuggestions()`/`reEvaluateCurrentThermostatSuggestion()` only run inside the `AddThermostatSuggestion`/`RemoveThermostatSuggestion` command handlers. Unlike the reference delegate (`ThermostatDelegate::StartExpirationTimer`/`TimerExpiredCallback` in `thermostat-delegate-impl.cpp`), there is **no scheduled timer** that fires exactly at a suggestion's `ExpirationTime`.

Practical effect: once the current suggestion's `ExpirationTime` elapses, it keeps being reported as `CurrentThermostatSuggestion` (and stays in `ThermostatSuggestions`) until the *next* `Add`/`RemoveThermostatSuggestion` call triggers cleanup — there's no spontaneous transition to `null`/the next candidate purely from time passing. This was a deliberate choice to keep this as a reactive bookkeeping helper consistent with the rest of `MatterbridgeThermostatServer` (no persistent timers inside a matter.js behavior class), rather than a scope creep into timer-based scheduling. Happy to add a real timer in a follow-up if that's wanted.

## Stacking / dependencies

Stacked on `feature/thermostat-suggestions-rebased` (PR #593 content, already applied to `dev`).
