### PR TITLE
fix(thermostat): cascade Preset removal to ThermostatSuggestions

### DIFF
--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -48,7 +48,13 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
    */
   override async initialize(): Promise<void> {
     await super.initialize();
-    this.reactTo(this.events.presets$AtomicChanged, (newPresets, oldPresets) => this.removeThermostatSuggestionsForRemovedPresets(newPresets, oldPresets));
+    // Pass an unbound method reference, matching matter.js's own reactor registrations (e.g. ThermostatServer's
+    // `this.reactTo(this.events.presets$AtomicChanged, this.#handlePresetsChanged)`): the Reactors system rebinds
+    // `this` to a fresh, correctly-scoped behavior instance for each reaction via `reactor.bind(behavior)`. Wrapping
+    // this in an arrow function would defeat that rebinding (arrow functions ignore `.bind()`), leaving `this.state`
+    // pointing at the stale instance from `initialize()` and failing at runtime with "its context has exited".
+    // oxlint-disable-next-line typescript/unbound-method
+    this.reactTo(this.events.presets$AtomicChanged, this.removeThermostatSuggestionsForRemovedPresets);
   }
 
   /**
@@ -77,15 +83,21 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     }
     if (removedPresetHandles.size === 0) return;
 
-    const removedSuggestions = this.state.thermostatSuggestions.filter((s) => removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
-    if (removedSuggestions.length === 0) return;
+    // Read thermostatSuggestions and currentThermostatSuggestion into plain local values up front, and do the
+    // filtering off those local copies: re-reading `this.state` after mutating it within the same reactor call can
+    // fail at runtime ("its container was removed"), since matter.js's own Presets validation reactor, registered on
+    // the same synchronous event, already mutates state before this one runs.
+    const currentSuggestions = [...this.state.thermostatSuggestions];
+    const remainingSuggestions = currentSuggestions.filter((s) => !removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
+    if (remainingSuggestions.length === currentSuggestions.length) return;
 
     const device = this.endpoint.stateOf(MatterbridgeServer);
     device.log.info(
-      `Removing ${removedSuggestions.length} thermostat suggestion(s) referencing removed preset(s) (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`,
+      `Removing ${currentSuggestions.length - remainingSuggestions.length} thermostat suggestion(s) referencing removed preset(s) (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`,
     );
-    this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => !removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
-    if (removedSuggestions.some((s) => s.uniqueId === this.state.currentThermostatSuggestion?.uniqueId)) {
+    const currentSuggestion = this.state.currentThermostatSuggestion;
+    this.state.thermostatSuggestions = remainingSuggestions;
+    if (currentSuggestion !== null && removedPresetHandles.has(Bytes.toHex(currentSuggestion.presetHandle))) {
       this.state.currentThermostatSuggestion = null;
       this.state.thermostatSuggestionNotFollowingReason = null;
     }

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -44,6 +44,54 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
   Thermostat.Feature.ThermostatSuggestions,
 ) {
   /**
+   * Initializes the behavior and reacts to Presets attribute changes to keep ThermostatSuggestions consistent.
+   */
+  override async initialize(): Promise<void> {
+    await super.initialize();
+    this.reactTo(this.events.presets$AtomicChanged, (newPresets, oldPresets) => this.removeThermostatSuggestionsForRemovedPresets(newPresets, oldPresets));
+  }
+
+  /**
+   * Removes ThermostatSuggestions entries referencing a Preset that was just removed by a Presets atomic write, and
+   * nulls CurrentThermostatSuggestion (clearing ThermostatSuggestionNotFollowingReason) when it referenced one of the
+   * removed presets.
+   *
+   * @param {Thermostat.Preset[]} newPresets - The committed Presets list after the atomic write.
+   * @param {Thermostat.Preset[]} oldPresets - The Presets list before the atomic write.
+   *
+   * @remarks
+   * matter.js does not yet provide a default implementation of the ThermostatSuggestions feature, so this cascade,
+   * required by the Presets attribute's "Effect on Receipt" (Matter 1.6 Application Cluster Spec § 4.3.11.50), is
+   * done here.
+   */
+  private removeThermostatSuggestionsForRemovedPresets(newPresets: Thermostat.Preset[], oldPresets: Thermostat.Preset[]): void {
+    const remainingPresetHandles = new Set<string>();
+    for (const preset of newPresets) {
+      if (preset.presetHandle !== null) remainingPresetHandles.add(Bytes.toHex(preset.presetHandle));
+    }
+    const removedPresetHandles = new Set<string>();
+    for (const preset of oldPresets) {
+      if (preset.presetHandle !== null && !remainingPresetHandles.has(Bytes.toHex(preset.presetHandle))) {
+        removedPresetHandles.add(Bytes.toHex(preset.presetHandle));
+      }
+    }
+    if (removedPresetHandles.size === 0) return;
+
+    const removedSuggestions = this.state.thermostatSuggestions.filter((s) => removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
+    if (removedSuggestions.length === 0) return;
+
+    const device = this.endpoint.stateOf(MatterbridgeServer);
+    device.log.info(
+      `Removing ${removedSuggestions.length} thermostat suggestion(s) referencing removed preset(s) (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`,
+    );
+    this.state.thermostatSuggestions = this.state.thermostatSuggestions.filter((s) => !removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
+    if (removedSuggestions.some((s) => s.uniqueId === this.state.currentThermostatSuggestion?.uniqueId)) {
+      this.state.currentThermostatSuggestion = null;
+      this.state.thermostatSuggestionNotFollowingReason = null;
+    }
+  }
+
+  /**
    * Forwards SetpointRaiseLower requests to the Matterbridge command handler and updates occupied setpoints.
    *
    * @param {Thermostat.SetpointRaiseLowerRequest} request - Setpoint-raise/lower request payload.

--- a/packages/core/src/behaviors/thermostatServer.ts
+++ b/packages/core/src/behaviors/thermostatServer.ts
@@ -89,15 +89,22 @@ export class MatterbridgeThermostatServer extends ThermostatServer.with(
     // the same synchronous event, already mutates state before this one runs.
     const currentSuggestions = [...this.state.thermostatSuggestions];
     const remainingSuggestions = currentSuggestions.filter((s) => !removedPresetHandles.has(Bytes.toHex(s.presetHandle)));
-    if (remainingSuggestions.length === currentSuggestions.length) return;
+    const currentSuggestion = this.state.currentThermostatSuggestion;
+    // Point 1 of the spec's "Effect on Receipt" nulls CurrentThermostatSuggestion whenever its own PresetHandle was
+    // removed, independently of whether any ThermostatSuggestions entry was removed (e.g. the list is already empty,
+    // or none of its entries reference the removed preset).
+    const clearCurrentSuggestion = currentSuggestion !== null && removedPresetHandles.has(Bytes.toHex(currentSuggestion.presetHandle));
+    if (remainingSuggestions.length === currentSuggestions.length && !clearCurrentSuggestion) return;
 
     const device = this.endpoint.stateOf(MatterbridgeServer);
-    device.log.info(
-      `Removing ${currentSuggestions.length - remainingSuggestions.length} thermostat suggestion(s) referencing removed preset(s) (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`,
-    );
-    const currentSuggestion = this.state.currentThermostatSuggestion;
-    this.state.thermostatSuggestions = remainingSuggestions;
-    if (currentSuggestion !== null && removedPresetHandles.has(Bytes.toHex(currentSuggestion.presetHandle))) {
+    if (remainingSuggestions.length !== currentSuggestions.length) {
+      device.log.info(
+        `Removing ${currentSuggestions.length - remainingSuggestions.length} thermostat suggestion(s) referencing removed preset(s) (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`,
+      );
+      this.state.thermostatSuggestions = remainingSuggestions;
+    }
+    if (clearCurrentSuggestion) {
+      device.log.info(`Clearing current thermostat suggestion referencing a removed preset (endpoint ${this.endpoint.maybeId}.${this.endpoint.maybeNumber})`);
       this.state.currentThermostatSuggestion = null;
       this.state.thermostatSuggestionNotFollowingReason = null;
     }

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1348,16 +1348,25 @@ describe('Server clusters and behaviors', () => {
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
 
-    // Seed 3 ThermostatSuggestions entries (uniqueId 2, 3, 4), all referencing preset 0, plus a CurrentThermostatSuggestion
-    // referencing the same preset, to set up the Presets removal cascade below (the scenario above already drains the list
-    // to empty, so it is reseeded directly here rather than through the add/remove commands). Removing preset 0 via a
-    // Presets atomic write deletes the referencing entries and, since CurrentThermostatSuggestion references that preset,
-    // nulls it (Matter 1.6 Application Cluster Spec § 4.3.11.50, points 1-2). matter.js only fires `presets$AtomicChanged`
-    // through a committed atomic write (AtomicWriteHandler), which local-actor/command-context test writes bypass
-    // entirely, so the event is emitted directly here, matching how AtomicWriteHandler.commitWrite() does it.
-    const preset0Suggestion = (uniqueId: number) => ({ uniqueId, presetHandle: Uint8Array.from([0]), effectiveTime: 1700000000, expirationTime: 1700001800 });
-    await thermostatSuggestion.setAttribute(Thermostat.id, 'thermostatSuggestions', [preset0Suggestion(2), preset0Suggestion(3), preset0Suggestion(4)]);
-    await thermostatSuggestion.setAttribute(Thermostat.id, 'currentThermostatSuggestion', preset0Suggestion(2));
+    // Seed 3 ThermostatSuggestions entries, all referencing preset 0, to set up the Presets removal cascade below (the
+    // scenario above already drains the list to empty, so it is reseeded here through real add commands, matching the
+    // earlier scenarios, rather than the try/finally-scoped flow above). The first, being immediately effective,
+    // becomes CurrentThermostatSuggestion as part of the add command's own re-evaluation. Removing preset 0 via a
+    // Presets atomic write deletes the referencing entries and, since CurrentThermostatSuggestion references that
+    // preset, nulls it (Matter 1.6 Application Cluster Spec § 4.3.11.50, points 1-2). matter.js only fires
+    // `presets$AtomicChanged` through a committed atomic write (AtomicWriteHandler), which local-actor/command-context
+    // test writes bypass entirely, so the event is emitted directly here, matching how AtomicWriteHandler.commitWrite()
+    // does it.
+    for (let i = 0; i < 3; i++) {
+      await thermostatSuggestion.invokeBehaviorCommand('Thermostat', 'addThermostatSuggestion', {
+        presetHandle: Uint8Array.from([0]),
+        effectiveTime: null,
+        expirationInMinutes: 30,
+      });
+    }
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(3);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toMatchObject({ presetHandle: Uint8Array.from([0]) });
+
     const thermostatSuggestionBehavior = MatterbridgeThermostatServer.with(
       Thermostat.Feature.Heating,
       Thermostat.Feature.Cooling,

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -1373,6 +1373,23 @@ describe('Server clusters and behaviors', () => {
       expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
     });
     expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+
+    // Regression test: CurrentThermostatSuggestion must be nulled whenever its own PresetHandle was removed, even
+    // when the ThermostatSuggestions list itself is unaffected (already empty here, so its length doesn't change).
+    // Matter 1.6 Application Cluster Spec § 4.3.11.50 point 1 applies to CurrentThermostatSuggestion independently
+    // of point 2 (which only covers ThermostatSuggestions entries).
+    await thermostatSuggestion.setAttribute(Thermostat.id, 'currentThermostatSuggestion', {
+      uniqueId: 5,
+      presetHandle: Uint8Array.from([1]),
+      effectiveTime: 1700000000,
+      expirationTime: 1700001800,
+    });
+    const presetsWithoutPreset1 = presetsWithoutPreset0.filter((p) => p.presetHandle === null || !Bytes.areEqual(p.presetHandle, Uint8Array.from([1])));
+    thermostatSuggestion.eventsOf(thermostatSuggestionBehavior).presets$AtomicChanged?.emit(presetsWithoutPreset1, presetsWithoutPreset0, undefined as never);
+    await vi.waitFor(() => {
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+    });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
   });
 
   test('ValveConfigurationAndControl server', async () => {

--- a/packages/core/vitest/behaviors/matterbridgeServer.test.ts
+++ b/packages/core/vitest/behaviors/matterbridgeServer.test.ts
@@ -14,6 +14,7 @@ const NAME = 'MatterbridgeServer';
 const MATTER_PORT = 11500;
 const MATTER_CREATE_ONLY = true;
 
+import { Bytes } from '@matter/general';
 import { DeviceEnergyManagementServer } from '@matter/node/behaviors/device-energy-management';
 import { OnOffBaseServer } from '@matter/node/behaviors/on-off';
 import { Status } from '@matter/types';
@@ -1344,6 +1345,34 @@ describe('Server clusters and behaviors', () => {
     } finally {
       vi.useRealTimers();
     }
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
+
+    // Seed 3 ThermostatSuggestions entries (uniqueId 2, 3, 4), all referencing preset 0, plus a CurrentThermostatSuggestion
+    // referencing the same preset, to set up the Presets removal cascade below (the scenario above already drains the list
+    // to empty, so it is reseeded directly here rather than through the add/remove commands). Removing preset 0 via a
+    // Presets atomic write deletes the referencing entries and, since CurrentThermostatSuggestion references that preset,
+    // nulls it (Matter 1.6 Application Cluster Spec § 4.3.11.50, points 1-2). matter.js only fires `presets$AtomicChanged`
+    // through a committed atomic write (AtomicWriteHandler), which local-actor/command-context test writes bypass
+    // entirely, so the event is emitted directly here, matching how AtomicWriteHandler.commitWrite() does it.
+    const preset0Suggestion = (uniqueId: number) => ({ uniqueId, presetHandle: Uint8Array.from([0]), effectiveTime: 1700000000, expirationTime: 1700001800 });
+    await thermostatSuggestion.setAttribute(Thermostat.id, 'thermostatSuggestions', [preset0Suggestion(2), preset0Suggestion(3), preset0Suggestion(4)]);
+    await thermostatSuggestion.setAttribute(Thermostat.id, 'currentThermostatSuggestion', preset0Suggestion(2));
+    const thermostatSuggestionBehavior = MatterbridgeThermostatServer.with(
+      Thermostat.Feature.Heating,
+      Thermostat.Feature.Cooling,
+      Thermostat.Feature.AutoMode,
+      Thermostat.Feature.Presets,
+      Thermostat.Feature.ThermostatSuggestions,
+    );
+    const presetsWithoutPreset0 = thermostatPresets.filter((p) => p.presetHandle === null || !Bytes.areEqual(p.presetHandle, Uint8Array.from([0])));
+    thermostatSuggestion.eventsOf(thermostatSuggestionBehavior).presets$AtomicChanged?.emit(presetsWithoutPreset0, thermostatPresets, undefined as never);
+    // The reactor runs in its own dedicated, independently-committed transaction (matching production), so its
+    // effect is not necessarily visible synchronously after emit() returns.
+    await vi.waitFor(() => {
+      expect(thermostatSuggestion.getAttribute(Thermostat.id, 'thermostatSuggestions')).toHaveLength(0);
+    });
+    expect(thermostatSuggestion.getAttribute(Thermostat.id, 'currentThermostatSuggestion')).toBeNull();
   });
 
   test('ValveConfigurationAndControl server', async () => {


### PR DESCRIPTION
## Summary

Implements the `ThermostatSuggestions` cascade required by the `Presets` attribute's "Effect on Receipt" (Matter 1.6 Application Cluster Spec § 4.3.11.50): when a committed `Presets` atomic write removes a preset, any `ThermostatSuggestions` entries referencing that preset are deleted, and `CurrentThermostatSuggestion` (with `ThermostatSuggestionNotFollowingReason`) is nulled if it was one of them.

This addresses **Finding 2** from the maintainer's final review of #597:
https://github.com/Luligu/matterbridge/pull/597#pullrequestreview-4944403941

> Finding 2 (spec-compliance, pre-existing, out of scope): Spec §4.3.11 requires that removing a Preset referenced by CurrentThermostatSuggestion nulls that attribute, and deletes any ThermostatSuggestions entries referencing the removed preset. No code in thermostatServer.ts implements this cascade — but this is unrelated to this PR's diff (which only touches the Add/Remove suggestion commands), so it's a gap worth a separate follow-up, not a blocker here.

Tracked in #599.

Supersedes #600, which was closed after merging `dev` (which had meanwhile picked up #597's own rewrite of the `ThermostatSuggestion server` test) produced a broken merge commit — a `suggestions` variable referenced out of scope, and a leftover test scenario built on state that no longer existed post-#597. This branch is rebased cleanly onto current `dev` instead, with the cascade test's setup re-derived against the current test flow.

## Implementation

`MatterbridgeThermostatServer` reacts to matter.js's `presets$AtomicChanged` event (fired by `AtomicWriteHandler` on a committed write), alongside matter.js's own built-in Presets validation reactor on the same event. matter.js does not implement the `ThermostatSuggestions` feature itself, so this cascade has to live in Matterbridge's own behavior — filed upstream as [matter-js/matter.js#4253](https://github.com/matter-js/matter.js/issues/4253) for tracking (native `ThermostatSuggestions` support, including this cascade). This code can be removed from Matterbridge once/if that lands.

While looking for a reference implementation to follow, this cascade turned out not to be implemented in the C++ reference SDK either (`ThermostatAttrAccess::PrecommitPresets()` / the example delegate's `CommitPendingPresets()` in connectedhomeip) — filed as [project-chip/connectedhomeip#73589](https://github.com/project-chip/connectedhomeip/issues/73589).

Two runtime-only pitfalls were found and fixed while validating against a real client (not caught by `tsc`/`oxlint`/unit tests):

- The reactor must be registered as an **unbound method reference** (`this.reactTo(event, this.method)`), not an arrow function wrapping it. matter.js's `Reactors` system rebinds `this` per reaction via `reactor.bind(behavior)`; arrow functions ignore `.bind()`, so wrapping the call in one silently kept `this` on the stale instance captured at `initialize()` time and crashed at runtime ("its context has exited"). Confirmed as intended matter.js behavior by a maintainer: https://github.com/matter-js/matter.js/issues/4253#issuecomment-5307436506
- `state.thermostatSuggestions` / `state.currentThermostatSuggestion` are read into plain local values **once, up front**, before mutating state. Re-reading `state` after a mutation, within the same synchronous reactor call, crashed ("its container was removed") because matter.js's own Presets validation reactor — registered on the same `presets$AtomicChanged` event — already mutates state earlier in the same dispatch.

A third, test-only pitfall surfaced while re-deriving the cascade test's setup against #597's rewritten test flow: bulk-writing the `thermostatSuggestions` list via `setAttribute` immediately before triggering the `presets$AtomicChanged` reactor raced with the reactor's own synchronous state write and threw "Cannot lock ... state synchronously" — caught internally by matter.js's reactor dispatch, so it only surfaced as a `vi.waitFor` timeout, not a visible error. Fixed by seeding the suggestions through real `addThermostatSuggestion` commands instead, matching the pattern used throughout the rest of the test.

## Validation

Built `matterbridge` core + `matterbridge-example-dynamic-platform`, ran an isolated local Matterbridge instance, paired with `chip-tool`, and drove the real `AtomicRequest` (BeginWrite/CommitWrite) + `WriteAttribute` flow to remove a non-built-in `Preset` referenced by a `ThermostatSuggestions` entry. Confirmed the entry was deleted and no server-side error was logged.

Added a Vitest regression test (`ThermostatSuggestion server` in `matterbridgeServer.test.ts`) that emits `presets$AtomicChanged` directly, matching how `AtomicWriteHandler.commitWrite()` fires it — local-actor and command-context test writes bypass `AtomicWriteHandler` entirely, so there's no other way to trigger this event from the Vitest harness. The reactor runs in its own independently-committed transaction, so the test polls with `vi.waitFor()` rather than asserting immediately after `emit()` returns.

Existing full test suite (42/42 in `matterbridgeServer.test.ts`), lint, format, and typecheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
