### PR TITLE
docs: add matterbridge-elgato to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,10 @@ Matterbridge plugin that exposes Litetouch 2000 lighting loads as Matter devices
 
 Matterbridge plugin that connects iRobot Roomba robot vacuums to the Matter fabric via their local MQTT broker and APIs.
 
+### [Elgato](https://github.com/passtas/matterbridge-elgato)
+
+Matterbridge dynamic platform plugin that exposes Elgato Key Light, Key Light Air and Light Strip to Matter using the local HTTP API with mDNS discovery.
+
 ## How to install and add a plugin with the frontend (best option)
 
 Just open the frontend on the link provided in the log, select a plugin and click install.


### PR DESCRIPTION
Adds `matterbridge-elgato` to the community plugins list in the README.

The plugin is a dynamic platform plugin that exposes Elgato Key Light, Key Light Air and Light Strip to Matter. Devices are discovered on the local network with mDNS and controlled through their local HTTP API, so no cloud account or Elgato software is required. On/off, brightness and colour temperature are mapped to the Matter colour temperature light device type.

- npm: https://www.npmjs.com/package/matterbridge-elgato
- Repository: https://github.com/passtas/matterbridge-elgato

Tested with Google Home; Apple Home and Alexa are expected to work via Matter.

Only README.md is touched, one entry appended at the end of the community plugins list, following the format of the existing entries. Branch is based on `dev` as per CONTRIBUTING.md.
