### PR TITLE
Expose optional productId on createDefaultBridgedDeviceBasicInformationClusterServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ If you like this project and find it useful, please consider giving it a star on
 - [frontend]: Bump `oxfmt` to v.0.67.0.
 - [frontend]: Bump `oxlint` to v.1.82.0.
 - [docker]: Change the base image of the **s6-rc-legacy** docker image from `node:22-bullseye-slim` to `node:22-bookworm-slim`. Debian 11 (bullseye) reached end of life on 2026-08-31 and its security `Release` file expired on 2026-09-07, breaking `apt-get update` during the build. Debian 12 (bookworm) still provides the `armhf` port and `node:22` still publishes `linux/arm/v7`, so `arm64`, `amd64` and `arm/v7` support is unchanged.
+- [MatterbridgeEndpoint]: `createDefaultBridgedDeviceBasicInformationClusterServer()` takes a new optional trailing `productId` parameter and reports it on the `BridgedDeviceBasicInformation` cluster when it is a valid uint16. `ProductId` had `disallowConform` on this cluster up to Matter 1.3, but Matter 1.4 (cluster revision 4) changed it to `describedConform` (optional when bridging Matter devices), so it is now spec compliant to report it. The parameter is optional and appended at the end of the signature, so all the existing call sites are unaffected and the attribute stays absent unless a caller opts in. It is also passed through by `deserialize()` and by `MatterbridgePlatform`, so a stored device doesn't lose its `productId`. Thanks Ludovic BOUÉ.
 
 <a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a>
 

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -156,7 +156,6 @@
 <h3 id="changed">Changed</h3>
 <ul>
 <li>[matterbridge]: Bump <code>matterbridge</code> version to v.3.10.10.</li>
-<li>[docker]: Change the base image of the <strong>s6-rc-legacy</strong> docker image from <code>node:22-bullseye-slim</code> to <code>node:22-bookworm-slim</code>. Debian 11 (bullseye) reached end of life on 2026-08-31 and its security <code>Release</code> file expired on 2026-09-07, breaking <code>apt-get update</code> during the build. Debian 12 (bookworm) still provides the <code>armhf</code> port and <code>node:22</code> still publishes <code>linux/arm/v7</code>, so <code>arm64</code>, <code>amd64</code> and <code>arm/v7</code> support is unchanged.</li>
 <li>[matterbridge]: Bump <code>@types/bun</code> to v.1.4.2.</li>
 <li>[matterbridge]: Bump <code>marked</code> to v.18.0.12.</li>
 <li>[matterbridge]: Bump <code>oxfmt</code> to v.0.67.0.</li>
@@ -175,6 +174,8 @@
 <li>[frontend]: Bump <code>vite</code> to v.8.3.0.</li>
 <li>[frontend]: Bump <code>oxfmt</code> to v.0.67.0.</li>
 <li>[frontend]: Bump <code>oxlint</code> to v.1.82.0.</li>
+<li>[docker]: Change the base image of the <strong>s6-rc-legacy</strong> docker image from <code>node:22-bullseye-slim</code> to <code>node:22-bookworm-slim</code>. Debian 11 (bullseye) reached end of life on 2026-08-31 and its security <code>Release</code> file expired on 2026-09-07, breaking <code>apt-get update</code> during the build. Debian 12 (bookworm) still provides the <code>armhf</code> port and <code>node:22</code> still publishes <code>linux/arm/v7</code>, so <code>arm64</code>, <code>amd64</code> and <code>arm/v7</code> support is unchanged.</li>
+<li>[MatterbridgeEndpoint]: <code>createDefaultBridgedDeviceBasicInformationClusterServer()</code> takes a new optional trailing <code>productId</code> parameter and reports it on the <code>BridgedDeviceBasicInformation</code> cluster when it is a valid uint16. <code>ProductId</code> had <code>disallowConform</code> on this cluster up to Matter 1.3, but Matter 1.4 (cluster revision 4) changed it to <code>describedConform</code> (optional when bridging Matter devices), so it is now spec compliant to report it. The parameter is optional and appended at the end of the signature, so all the existing call sites are unaffected and the attribute stays absent unless a caller opts in. It is also passed through by <code>deserialize()</code> and by <code>MatterbridgePlatform</code>, so a stored device doesn&#39;t lose its <code>productId</code>. Thanks Ludovic BOUÉ.</li>
 </ul>
 <p><a href="https://www.buymeacoffee.com/luligugithub"><img src="https://matterbridge.io/assets/bmc-button.svg" alt="Buy me a coffee" width="80"></a></p>
 <h2 id="3109-2026-09-11">[3.10.9] - 2026-09-11</h2>

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -2207,6 +2207,7 @@ export class MatterbridgeEndpoint extends Endpoint {
           serializedDevice.productLabel,
           serializedDevice.productUrl,
           serializedDevice.configurationVersion,
+          serializedDevice.productId,
         );
       else if (clusterId === BasicInformation.id)
         device.createDefaultBasicInformationClusterServer(
@@ -2411,10 +2412,10 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {string} [productLabel] - The product label of the device. Default is 'Matter Bridged Endpoint'.
    * @param {string} [productUrl] - The product URL of the device. Default is 'https://matterbridge.io'.
    * @param {number} [configurationVersion] - The configuration version of the device. Default is 1.
+   * @param {number} [productId] - The product ID of the device. Optional: the ProductId attribute has "desc" conformance on BridgedDeviceBasicInformation, so it is only reported when explicitly provided.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
    * @remarks
-   * - The productId doesn't exist on the BridgedDeviceBasicInformation cluster.
    * - The bridgedNode device type must be added to the deviceTypeList of the Descriptor cluster.
    * - The product URL must follow RFC 1738 syntax, use the HTTPS scheme and contain at most 256 ASCII characters.
    */
@@ -2431,12 +2432,13 @@ export class MatterbridgeEndpoint extends Endpoint {
     productLabel: string = 'Matter Bridged Endpoint',
     productUrl: string = 'https://matterbridge.io',
     configurationVersion: number = 1,
+    productId?: number,
   ): this {
     this.log.logName = deviceName;
     this.deviceName = deviceName;
     this.serialNumber = serialNumber;
     this.uniqueId = createUniqueId(deviceName, serialNumber, vendorName, productName);
-    this.productId = undefined;
+    this.productId = productId;
     this.productName = productName;
     this.productLabel = productLabel;
     this.productUrl = productUrl;
@@ -2466,6 +2468,7 @@ export class MatterbridgeEndpoint extends Endpoint {
         hardwareVersionString: isValidString(hardwareVersionString, 1, 64) ? hardwareVersionString : '1.0.0',
         configurationVersion: isValidInteger(configurationVersion, 1, UINT32_MAX) ? configurationVersion : 1,
         reachable: true,
+        ...(productId !== undefined && isValidInteger(productId, 0, UINT16_MAX) ? { productId } : {}),
       },
     );
     return this;

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -2412,10 +2412,11 @@ export class MatterbridgeEndpoint extends Endpoint {
    * @param {string} [productLabel] - The product label of the device. Default is 'Matter Bridged Endpoint'.
    * @param {string} [productUrl] - The product URL of the device. Default is 'https://matterbridge.io'.
    * @param {number} [configurationVersion] - The configuration version of the device. Default is 1.
-   * @param {number} [productId] - The product ID of the device. Optional: the ProductId attribute has "desc" conformance on BridgedDeviceBasicInformation, so it is only reported when explicitly provided.
+   * @param {number} [productId] - The product ID of the device. Optional: not set by default, so it is only reported when explicitly provided here.
    * @returns {this} The current MatterbridgeEndpoint instance for chaining.
    *
    * @remarks
+   * - ProductId had disallowConform on BridgedDeviceBasicInformation up to Matter 1.3. Matter 1.4 (cluster revision 4) changed it to describedConform (optional, "optional when bridging Matter devices"), so it is safe to report when the caller provides one.
    * - The bridgedNode device type must be added to the deviceTypeList of the Descriptor cluster.
    * - The product URL must follow RFC 1738 syntax, use the HTTPS scheme and contain at most 256 ASCII characters.
    */

--- a/packages/core/src/matterbridgeEndpoint.ts
+++ b/packages/core/src/matterbridgeEndpoint.ts
@@ -2469,7 +2469,7 @@ export class MatterbridgeEndpoint extends Endpoint {
         hardwareVersionString: isValidString(hardwareVersionString, 1, 64) ? hardwareVersionString : '1.0.0',
         configurationVersion: isValidInteger(configurationVersion, 1, UINT32_MAX) ? configurationVersion : 1,
         reachable: true,
-        ...(productId !== undefined && isValidInteger(productId, 0, UINT16_MAX) ? { productId } : {}),
+        ...(isValidInteger(productId, 0, UINT16_MAX) ? { productId } : {}),
       },
     );
     return this;

--- a/packages/core/src/matterbridgePlatform.ts
+++ b/packages/core/src/matterbridgePlatform.ts
@@ -666,6 +666,7 @@ export class MatterbridgePlatform {
           device.productLabel === 'Matter Endpoint' ? 'Matter Bridged Endpoint' : device.productLabel,
           device.productUrl,
           device.configurationVersion,
+          device.productId,
         );
       }
     }

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -280,42 +280,66 @@ describe('Matterbridge ' + NAME, () => {
   });
 
   test('createDefaultBridgedDeviceBasicInformationClusterServer', async () => {
-    const productLabel = `Matterbridge ${'P'.repeat(70)}`;
-    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
-    expect(device).toBeDefined();
-    device.createDefaultBridgedDeviceBasicInformationClusterServer(
-      'OnOffLight',
-      '1234',
-      0xfff1,
-      'Matterbridge',
-      'Light',
-      1.5,
-      '',
-      1.5,
-      '',
-      productLabel,
-      'http://matterbridge.io/device',
-      1.5,
-    );
-    expect(device.hasClusterServer(BasicInformation)).toBe(false);
-    expect(device.hasClusterServer(BridgedDeviceBasicInformation)).toBe(true);
-    expect(device.softwareVersion).toBe(1.5);
-    expect(device.softwareVersionString).toBe('');
-    expect(device.hardwareVersion).toBe(1.5);
-    expect(device.hardwareVersionString).toBe('');
-    expect(device.productLabel).toBe(productLabel);
-    expect(device.productUrl).toBe('http://matterbridge.io/device');
-    expect(device.configurationVersion).toBe(1.5);
+        const productLabel = `Matterbridge ${'P'.repeat(70)}`;
+            const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+                expect(device).toBeDefined();
+                    device.createDefaultBridgedDeviceBasicInformationClusterServer(
+                          'OnOffLight',
+                                '1234',
+                                      0xfff1,
+                                            'Matterbridge',
+                                                  'Light',
+                                                        1.5,
+                                                              '',
+                                                                    1.5,
+                                                                          '',
+                                                                                productLabel,
+                                                                                      'http://matterbridge.io/device',
+                                                                                            1.5,
+                                                                                                );
+                                                                                                    expect(device.hasClusterServer(BasicInformation)).toBe(false);
+                                                                                                        expect(device.hasClusterServer(BridgedDeviceBasicInformation)).toBe(true);
+                                                                                                            expect(device.productId).toBeUndefined();
+                                                                                                                expect(device.softwareVersion).toBe(1.5);
+                                                                                                                    expect(device.softwareVersionString).toBe('');
+                                                                                                                        expect(device.hardwareVersion).toBe(1.5);
+                                                                                                                            expect(device.hardwareVersionString).toBe('');
+                                                                                                                                expect(device.productLabel).toBe(productLabel);
+                                                                                                                                    expect(device.productUrl).toBe('http://matterbridge.io/device');
+                                                                                                                                        expect(device.configurationVersion).toBe(1.5);
 
-    await add(device);
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersion')).toBe(1);
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersionString')).toBe('1.0.0');
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersion')).toBe(1);
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersionString')).toBe('1.0.0');
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productLabel')).toBe('P'.repeat(64));
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productUrl')).toBe('https://matterbridge.io');
-    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'configurationVersion')).toBe(1);
-  });
+                                                                                                                                            await add(device);
+                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersion')).toBe(1);
+                                                                                                                                                    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersionString')).toBe('1.0.0');
+                                                                                                                                                        expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersion')).toBe(1);
+                                                                                                                                                            expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersionString')).toBe('1.0.0');
+                                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productLabel')).toBe('P'.repeat(64));
+                                                                                                                                                                    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productUrl')).toBe('https://matterbridge.io');
+                                                                                                                                                                        expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'configurationVersion')).toBe(1);
+                                                                                                                                                                            // ProductId has describedConform on BridgedDeviceBasicInformation since Matter 1.4: omitted here since not passed to createDefaultBridgedDeviceBasicInformationClusterServer().
+                                                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
+                                                                                                                                                                                  });
+
+                                                                                                                                                                                    test('createDefaultBridgedDeviceBasicInformationClusterServer with a valid productId', async () => {
+                                                                                                                                                                                        const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-productId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+                                                                                                                                                                                            expect(device).toBeDefined();
+                                                                                                                                                                                                device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x8000);
+                                                                                                                                                                                                    expect(device.productId).toBe(0x8000);
+
+                                                                                                                                                                                                        await add(device);
+                                                                                                                                                                                                            expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBe(0x8000);
+                                                                                                                                                                                                              });
+
+                                                                                                                                                                                                                test('createDefaultBridgedDeviceBasicInformationClusterServer with an out of range productId', async () => {
+                                                                                                                                                                                                                    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-invalidProductId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+                                                                                                                                                                                                                        expect(device).toBeDefined();
+                                                                                                                                                                                                                            device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x10000);
+                                                                                                                                                                                                                                expect(device.productId).toBe(0x10000);
+
+                                                                                                                                                                                                                                    await add(device);
+                                                                                                                                                                                                                  expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
+                                                                                                                                                                                                                  
+  })  });
 
   test('createDefaultGroupsServer', async () => {
     const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight12', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -280,66 +280,65 @@ describe('Matterbridge ' + NAME, () => {
   });
 
   test('createDefaultBridgedDeviceBasicInformationClusterServer', async () => {
-        const productLabel = `Matterbridge ${'P'.repeat(70)}`;
-            const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
-                expect(device).toBeDefined();
-                    device.createDefaultBridgedDeviceBasicInformationClusterServer(
-                          'OnOffLight',
-                                '1234',
-                                      0xfff1,
-                                            'Matterbridge',
-                                                  'Light',
-                                                        1.5,
-                                                              '',
-                                                                    1.5,
-                                                                          '',
-                                                                                productLabel,
-                                                                                      'http://matterbridge.io/device',
-                                                                                            1.5,
-                                                                                                );
-                                                                                                    expect(device.hasClusterServer(BasicInformation)).toBe(false);
-                                                                                                        expect(device.hasClusterServer(BridgedDeviceBasicInformation)).toBe(true);
-                                                                                                            expect(device.productId).toBeUndefined();
-                                                                                                                expect(device.softwareVersion).toBe(1.5);
-                                                                                                                    expect(device.softwareVersionString).toBe('');
-                                                                                                                        expect(device.hardwareVersion).toBe(1.5);
-                                                                                                                            expect(device.hardwareVersionString).toBe('');
-                                                                                                                                expect(device.productLabel).toBe(productLabel);
-                                                                                                                                    expect(device.productUrl).toBe('http://matterbridge.io/device');
-                                                                                                                                        expect(device.configurationVersion).toBe(1.5);
+    const productLabel = `Matterbridge ${'P'.repeat(70)}`;
+    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+    expect(device).toBeDefined();
+    device.createDefaultBridgedDeviceBasicInformationClusterServer(
+      'OnOffLight',
+      '1234',
+      0xfff1,
+      'Matterbridge',
+      'Light',
+      1.5,
+      '',
+      1.5,
+      '',
+      productLabel,
+      'http://matterbridge.io/device',
+      1.5,
+    );
+    expect(device.hasClusterServer(BasicInformation)).toBe(false);
+    expect(device.hasClusterServer(BridgedDeviceBasicInformation)).toBe(true);
+    expect(device.productId).toBeUndefined();
+    expect(device.softwareVersion).toBe(1.5);
+    expect(device.softwareVersionString).toBe('');
+    expect(device.hardwareVersion).toBe(1.5);
+    expect(device.hardwareVersionString).toBe('');
+    expect(device.productLabel).toBe(productLabel);
+    expect(device.productUrl).toBe('http://matterbridge.io/device');
+    expect(device.configurationVersion).toBe(1.5);
 
-                                                                                                                                            await add(device);
-                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersion')).toBe(1);
-                                                                                                                                                    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersionString')).toBe('1.0.0');
-                                                                                                                                                        expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersion')).toBe(1);
-                                                                                                                                                            expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersionString')).toBe('1.0.0');
-                                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productLabel')).toBe('P'.repeat(64));
-                                                                                                                                                                    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productUrl')).toBe('https://matterbridge.io');
-                                                                                                                                                                        expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'configurationVersion')).toBe(1);
-                                                                                                                                                                            // ProductId has describedConform on BridgedDeviceBasicInformation since Matter 1.4: omitted here since not passed to createDefaultBridgedDeviceBasicInformationClusterServer().
-                                                                                                                                                                                expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
-                                                                                                                                                                                  });
+    await add(device);
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersion')).toBe(1);
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'softwareVersionString')).toBe('1.0.0');
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersion')).toBe(1);
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'hardwareVersionString')).toBe('1.0.0');
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productLabel')).toBe('P'.repeat(64));
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productUrl')).toBe('https://matterbridge.io');
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'configurationVersion')).toBe(1);
+    // ProductId has describedConform on BridgedDeviceBasicInformation since Matter 1.4: omitted here since not passed to createDefaultBridgedDeviceBasicInformationClusterServer().
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
+  });
 
-                                                                                                                                                                                    test('createDefaultBridgedDeviceBasicInformationClusterServer with a valid productId', async () => {
-                                                                                                                                                                                        const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-productId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
-                                                                                                                                                                                            expect(device).toBeDefined();
-                                                                                                                                                                                                device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x8000);
-                                                                                                                                                                                                    expect(device.productId).toBe(0x8000);
+  test('createDefaultBridgedDeviceBasicInformationClusterServer with a valid productId', async () => {
+    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-productId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+    expect(device).toBeDefined();
+    device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x8000);
+    expect(device.productId).toBe(0x8000);
 
-                                                                                                                                                                                                        await add(device);
-                                                                                                                                                                                                            expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBe(0x8000);
-                                                                                                                                                                                                              });
+    await add(device);
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBe(0x8000);
+  });
 
-                                                                                                                                                                                                                test('createDefaultBridgedDeviceBasicInformationClusterServer with an out of range productId', async () => {
-                                                                                                                                                                                                                    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-invalidProductId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
-                                                                                                                                                                                                                        expect(device).toBeDefined();
-                                                                                                                                                                                                                            device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x10000);
-                                                                                                                                                                                                                                expect(device.productId).toBe(0x10000);
+  test('createDefaultBridgedDeviceBasicInformationClusterServer with an out of range productId', async () => {
+    const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-invalidProductId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
+    expect(device).toBeDefined();
+    device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x10000);
+    expect(device.productId).toBe(0x10000);
 
-                                                                                                                                                                                                                                    await add(device);
-                                                                                                                                                                                                                  expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
-                                                                                                                                                                                                                  
-  })  });
+    await add(device);
+    expect(device.getAttribute(BridgedDeviceBasicInformation.id, 'productId')).toBeUndefined();
+  });
 
   test('createDefaultGroupsServer', async () => {
     const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight12', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });

--- a/packages/core/vitest/matterbridgeEndpoint-default.test.ts
+++ b/packages/core/vitest/matterbridgeEndpoint-default.test.ts
@@ -323,7 +323,21 @@ describe('Matterbridge ' + NAME, () => {
   test('createDefaultBridgedDeviceBasicInformationClusterServer with a valid productId', async () => {
     const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-productId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
     expect(device).toBeDefined();
-    device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x8000);
+    device.createDefaultBridgedDeviceBasicInformationClusterServer(
+      'OnOffLight',
+      '1234',
+      0xfff1,
+      'Matterbridge',
+      'Light',
+      1,
+      '1.0.0',
+      1,
+      '1.0.0',
+      'Light',
+      'https://matterbridge.io',
+      1,
+      0x8000,
+    );
     expect(device.productId).toBe(0x8000);
 
     await add(device);
@@ -333,7 +347,21 @@ describe('Matterbridge ' + NAME, () => {
   test('createDefaultBridgedDeviceBasicInformationClusterServer with an out of range productId', async () => {
     const device = new MatterbridgeEndpoint(onOffLight, { id: 'OnOffLight11-invalidProductId', tagList: [{ mfgCode: null, namespaceId: 0x07, tag: 1, label: 'Light' }] });
     expect(device).toBeDefined();
-    device.createDefaultBridgedDeviceBasicInformationClusterServer('OnOffLight', '1234', 0xfff1, 'Matterbridge', 'Light', 1, '1.0.0', 1, '1.0.0', 'Light', 'https://matterbridge.io', 1, 0x10000);
+    device.createDefaultBridgedDeviceBasicInformationClusterServer(
+      'OnOffLight',
+      '1234',
+      0xfff1,
+      'Matterbridge',
+      'Light',
+      1,
+      '1.0.0',
+      1,
+      '1.0.0',
+      'Light',
+      'https://matterbridge.io',
+      1,
+      0x10000,
+    );
     expect(device.productId).toBe(0x10000);
 
     await add(device);


### PR DESCRIPTION
## Summary

`createDefaultBridgedDeviceBasicInformationClusterServer()` hardcodes `productId` to `undefined` and never reports it on the `BridgedDeviceBasicInformation` cluster, with no way for a caller to override it.
The method doesn't even accept a `productId` parameter.

This was correct up to Matter 1.3, where `ProductID` had `disallowConform` on `BridgedDeviceBasicInformation` (the attribute was explicitly forbidden on this cluster). **Matter 1.4** (cluster revision 4) changed its conformance to `describedConform` (optional), per the CSA data model revision history: *"Updated conformance for UniqueID to mandatory, ProductID to optional when bridging Matter devices"* ([BridgedDeviceBasicInformationCluster.xml](https://github.com/project-chip/connectedhomeip/blob/master/data_model/1.5/clusters/BridgedDeviceBasicInformationCluster.xml)). So reporting it is now spec-compliant when a caller has a meaningful value to provide.

This matters in practice because a bridged device's `productID` is currently structurally unavailable to any downstream consumer that keys behavior off `(vendorID, productID)` — e.g. Home Assistant's Matter integration only accepts custom entity-name labels (`ha_entitylabel`) for an allowlisted set of vendor/product ID pairs, including the Matter test VID/PIDs (`0xFFF1`/`0x8000`, matching Matterbridge's own defaults). Since bridged devices never report a `productID`, that allowlist can never match, regardless of label name (see [home-assistant/core#161974](https://github.com/home-assistant/core/pull/161974)).

## Changes

- Add an optional trailing `productId?: number` parameter to `createDefaultBridgedDeviceBasicInformationClusterServer()`.
- Set `this.productId = productId` instead of the hardcoded `undefined`.
- Include `productId` in the `BridgedDeviceBasicInformationServer` state only when provided and valid (`isValidInteger(productId, 0, UINT16_MAX)`), so existing behavior (attribute omitted) is unchanged when the parameter is not passed.
- Pass `serializedDevice.productId` through in `deserialize()` so a round-tripped (serialized/deserialized) device doesn't silently lose its `productId`.
- Update the JSDoc: replace the outdated "productId doesn't exist on the BridgedDeviceBasicInformation cluster" remark with the accurate Matter 1.3 → 1.4 conformance history.

## Compatibility

Fully backward compatible: the new parameter is optional and appended at the end of the signature, so every existing positional call site (core and plugins) is unaffected, and the default reported state (`productId` omitted) is unchanged unless a caller explicitly opts in.

## Testing

- [x] Verified TypeScript compiles (`npm run build` / equivalent).
- [x] Verified `BridgedDeviceBasicInformation.ProductID` is now reported when `productId` is passed, and stays absent when it isn't.

## Context

- https://github.com/Luligu/matterbridge-example-dynamic-platform/pull/76