### PR TITLE
Widen the Attribute Value tooltip for long/nested values

### DIFF
--- a/apps/frontend/src/components/ConditionalTooltip.tsx
+++ b/apps/frontend/src/components/ConditionalTooltip.tsx
@@ -51,7 +51,20 @@ export function ConditionalTooltip({ title, children }: ConditionalTooltipProps)
       disableFocusListener
       disableTouchListener
       slotProps={{
-        tooltip: { sx: { fontSize: '14px', fontWeight: 'normal', color: '#ffffff', backgroundColor: 'var(--primary-color)' } },
+        tooltip: {
+          sx: {
+            fontSize: '14px',
+            fontWeight: 'normal',
+            color: '#ffffff',
+            backgroundColor: 'var(--primary-color)',
+            // Wide, wrapping tooltip so long/nested attribute values (e.g. a struct with an array of
+            // structs, like DeviceEnergyManagement's Forecast.Slots) stay readable instead of wrapping
+            // into a tall, narrow column at MUI's default 300px tooltip width.
+            maxWidth: 500,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          },
+        },
       }}
     >
       <span ref={spanRef} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} style={spanStyle}>


### PR DESCRIPTION
Fixes #637

(Replaces #638, which was accidentally based on a diverged local `dev`. Same single commit, now rebased cleanly on current `dev`.)

## Problem

The Clusters table's **Attribute Value** tooltip (`ConditionalTooltip`) inherited MUI's default `maxWidth: 300` with no wrapping override. For a deeply nested attribute value — e.g. `DeviceEnergyManagement`'s `Forecast` struct, which contains an array of `SlotStruct` entries — the tooltip wrapped into a very tall, very narrow column that's effectively unreadable. This looks exactly like the nested field (`Slots`) is missing, which it isn't.

## Verification that this was display-only

- `chip-tool` (independent CHIP C++ SDK) reading the `Forecast` attribute directly off the wire: all slots present and correct.
- The stored `endpoint.state` value itself: `Object.keys()`, `JSON.stringify()`, and the `slots` property descriptor (`enumerable: true`) all show the data is complete and correctly shaped.
- Built the frontend with this fix and drove it against a real Matterbridge instance (with a DeviceEnergyManagement device registered): the widened tooltip renders the full `Forecast` value, all 3 slots included, on hover.

So the data was always correct end-to-end; only the tooltip's fixed narrow width made it unreadable.

## Fix

Widens `ConditionalTooltip`'s `sx.maxWidth` from 300 to 500 and adds `whiteSpace: 'pre-wrap'` / `wordBreak: 'break-word'`, so long or nested attribute values wrap into something legible on hover instead of a tall narrow sliver.

## Testing

- `npm run format:check` / `npm run lint` / `npm run typecheck` on the changed file: clean (pre-existing unrelated typecheck errors elsewhere in the frontend untouched).
- `npm run test -- ConditionalTooltip.test.tsx MbfTable`: 24/24 passing.
- Manual verification against a running Matterbridge instance, as noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)